### PR TITLE
(RSM) emme toolbox update to permit targeted link attribute changes

### DIFF
--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -1424,9 +1424,9 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
             for link_edits in network_editor_data.get('traffic',[]):
                 if link_edits.get('delete_link', False):
                     for ij in link_edits['i-j']:
-                        traffic_network.delete_link(ij[0], ij[1], cascade=True)
+                        network.delete_link(ij[0], ij[1], cascade=True)
                 else:
-                    for link in traffic_network.links():
+                    for link in network.links():
                         if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
                             #this format permits only one attribute change per edit
                             #could explore using set_attribute_values() method in EMME API

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -74,7 +74,7 @@ import heapq as _heapq
 
 import traceback as _traceback
 import os
-import yaml
+import yaml #for network editor yaml file
 
 _join = os.path.join
 _dir = os.path.dirname
@@ -87,7 +87,7 @@ FILE_NAMES = {
     "FARES": "special_fares.txt",
     "OFF_PEAK": "off_peak_toll_factors.csv",
     "VEHICLE_CLASS": "vehicle_class_toll_factors.csv",
-    "NETWORK_EDITS": "network_edits.yaml"
+    "NETWORK_EDITS": "network_edits.yaml" #prepare the network ymal file
 }
 
 
@@ -1359,34 +1359,12 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
             }
         }
 
-        # Check if network editor file is in inputs
-        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        network_editor_bool = False
-        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        if os.path.exists(network_editor_yaml_path):
-            #msg = #"Adjusting off-peak tolls based on factors from %s" % off_peak_factor_file
-            #self._log.append({"type": "text", "content": msg})
-            network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-            with open(network_editor_yaml_path, "r") as stream:
-                network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
-
         for link in network.links():
             # Change SR125 toll speed to 70MPH
             if link["@lane_restriction"] == 4 and link.type == 1:
                 link["@speed_posted"] = 70
 
             link["@cost_operating"] = link.length * aoc
-
-            if network_editor_bool:
-                for link_edits in network_editor_data:
-                    if link["@tcov_id"] in link_edits["@tcov_id"]:
-                        #this format permits only one attribute change per edit
-                        try:
-                            link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                        except KeyError: #one of two solutions should probably be removed
-                            setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
 
             # Expand off-peak TOD attributes, copy peak period attributes
             for time, src_time in zip(time_periods, src_time_periods):
@@ -1499,6 +1477,27 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                         (set(periods) - set(factors.keys())), vehicle_class_factor_file, name)
                     self._log.append({"type": "text", "content": msg})
                     self._error.append(msg)
+
+        # add check for network editor yaml file
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "loaded YAML"})
+        if network_editor_bool:
+            for link in network.links():
+                for link_edits in network_editor_data:
+                    if link["@tcov_id"] in link_edits["@tcov_id"]:
+                        #this format permits only one attribute change per edit
+                        try:
+                            link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                        except KeyError: #one of two solutions should probably be removed
+                            setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
 
         def lookup_link_name(link):
             for attr_name in ["#name", "#name_from", "#name_to"]:

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -443,6 +443,35 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
 
         traffic_network = _network.Network()
         transit_network = _network.Network()
+
+
+        # add check for network editor yaml file
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "loaded YAML"})
+        if network_editor_bool:
+            for link_edits in network_editor_data.get('traffic',[]):
+                if link_edits.get('delete_link', False):
+                    for ij in link_edits['i-j']:
+                        traffic_network.delete_link(ij[0], ij[1], cascade=True)
+                else:
+                    for link in traffic_network.links():
+                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
+                            #this format permits only one attribute change per edit
+                            #could explore using set_attribute_values() method in EMME API
+                            try:
+                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                            except KeyError: #one of two solutions should probably be removed
+                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
+
+
         try:
             if self.traffic_scenario_id or self.merged_scenario_id:
                 for elem_type, attrs in traffic_attr_map.iteritems():
@@ -1406,32 +1435,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
 
                 link["@time_inter" + time] = link["time_inter" + src_time]
                 link["@toll" + time] = link["toll" + src_time]
-
-        # add check for network editor yaml file
-        # Check if network editor file is in inputs
-        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        network_editor_bool = False
-        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        if os.path.exists(network_editor_yaml_path):
-            network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-            with open(network_editor_yaml_path, "r") as stream:
-                network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
-        if network_editor_bool:
-            for link_edits in network_editor_data.get('traffic',[]):
-                if link_edits.get('delete_link', False):
-                    for ij in link_edits['i-j']:
-                        network.delete_link(ij[0], ij[1], cascade=True)
-                else:
-                    for link in network.links():
-                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
-                            #this format permits only one attribute change per edit
-                            #could explore using set_attribute_values() method in EMME API
-                            try:
-                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                            except KeyError: #one of two solutions should probably be removed
-                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
 
         off_peak_factor_file = FILE_NAMES["OFF_PEAK"]
         if os.path.exists(_join(self.source, off_peak_factor_file)):

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -598,7 +598,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 # managed lanes, free for HOV3+, tolls for SOV and HOV2
                 if arc["ITOLLO"] + arc["ITOLLA"] + arc["ITOLLP"]  > 0:
                     return modes_toll_lanes[arc["ITRUCK"]] | modes_HOV3
-                # special case of I-15 managed lanes for base year and 2020, no build 
+                # special case of I-15 managed lanes for base year and 2020, no build
                 elif arc["IFC"] == 1 and arc["IPROJ"] in [41, 42, 486, 373, 711]:
                     return modes_toll_lanes[arc["ITRUCK"]] | modes_HOV3
                 elif arc["IFC"] == 8 or arc["IFC"] == 9:
@@ -786,7 +786,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 self._log.append({"type": "text", "content": "\tYAML Path: %s" % network_editor_yaml_path})
         else:
             self._log.append({"type": "text", "content": "NO Network Edits YAML to load"})
-            
+
         # Create nodes and links
         for arc in data:
             if not arc_filter(arc):
@@ -813,7 +813,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 if arc_id_name == "HWYCOV-ID":
                     for link_edits in network_editor_data.get('raw_network',[]):
                         if arc["HWYCOV-ID"] in link_edits.get("@tcov_id",[]):
-                            #could explore using set_attribute_values() method in EMME API
                             for attribute,value in link_edits["attributes_to_edit"].items():
                                 arc[attribute] = value
 
@@ -1222,20 +1221,24 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
         pass_values.add_attribute(_dt.Attribute("cost", _np.array(pass_costs).astype("f8")))
         gen_utils.DataTableProc("%s_transit_passes" % self.data_table_name, data=pass_values)
 
+        # Check if network editor file is in inputs
         network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
         network_editor_bool = False
         network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        self._log.append({"type": "header", "content": "__Network Edits"})
         if os.path.exists(network_editor_yaml_path):
             network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
             with open(network_editor_yaml_path, "r") as stream:
                 network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
+                self._log.append({"type": "text", "content": "Successfully loaded Network Edits YAML"})
+                self._log.append({"type": "text", "content": "\tYAML Path: %s" % network_editor_yaml_path})
+        else:
+            self._log.append({"type": "text", "content": "NO Network Edits YAML to load"})
+
         if network_editor_bool:
             for link_edits in network_editor_data.get('transit',[]):
                 for link in network.links():
                     if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
-                        #could explore using set_attribute_values() method in EMME API
                         for attribute,value in link_edits["attributes_to_edit"].items():
                             link[attribute] = value
 
@@ -1429,17 +1432,27 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 link["@time_inter" + time] = link["time_inter" + src_time]
                 link["@toll" + time] = link["toll" + src_time]
 
-        # # add check for network editor yaml file
-        # # Check if network editor file is in inputs
-        # network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        # network_editor_bool = False
-        # network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        # if os.path.exists(network_editor_yaml_path):
-        #     network_editor_bool = True
-        #     self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-        #     with open(network_editor_yaml_path, "r") as stream:
-        #         network_editor_data = yaml.safe_load(stream)
-        #         self._log.append({"type": "text", "content": "loaded YAML"})
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        self._log.append({"type": "header", "content": "__Network Edits"})
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "Successfully loaded Network Edits YAML"})
+                self._log.append({"type": "text", "content": "\tYAML Path: %s" % network_editor_yaml_path})
+        else:
+            self._log.append({"type": "text", "content": "NO Network Edits YAML to load"})
+
+        if network_editor_bool:
+            for link_edits in network_editor_data.get('traffic',[]):
+                for link in network.links():
+                    if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
+                        for attribute,value in link_edits["attributes_to_edit"].items():
+                            link[attribute] = value
+
         # if network_editor_bool:
         #     for link_edits in network_editor_data.get('traffic',[]):
         #         if link_edits.get('delete_link', False):
@@ -1447,13 +1460,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
         #                 network.delete_link(ij[0], ij[1], cascade=True)
         #         else:
         #             for link in network.links():
-        #                 if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
-        #                     #this format permits only one attribute change per edit
-        #                     #could explore using set_attribute_values() method in EMME API
-        #                     try:
-        #                         link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-        #                     except KeyError: #one of two solutions should probably be removed
-        #                         setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
 
 
         off_peak_factor_file = FILE_NAMES["OFF_PEAK"]
@@ -1484,7 +1490,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
             factors = [(3.0/12.0), 1.0, (6.5/12.0), (3.5/3.0), (8.0/12.0)]
             for f, time, src_time in zip(factors, time_periods, src_time_periods):
                 if link["capacity_link" + src_time] != 999999:
-                    link["@capacity_link" + time] = f * link["capacity_link" + src_time]	
+                    link["@capacity_link" + time] = f * link["capacity_link" + src_time]
                 else:
                     link["@capacity_link" + time] = 999999
                 if link["capacity_inter" + src_time] != 999999:

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -773,6 +773,18 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
         if arc_filter is None:
             arc_filter = lambda arc : True
 
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "loaded YAML"})
+            
+
         # Create nodes and links
         for arc in data:
             if not arc_filter(arc):
@@ -793,6 +805,16 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 self._error.append(msg)
                 self._split_link(network, i_node, j_node, new_node_id)
                 new_node_id += 1
+
+            #arc edits to raw_network
+            # if network_editor_bool:
+            for link_edits in network_editor_data.get('raw_network',[]):
+                if arc["HWYCOV-ID"] in link_edits.get("@tcov_id",[]):
+                    #could explore using set_attribute_values() method in EMME API
+                    try:
+                        arc[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                    except KeyError:
+                        setattr(arc, link_edits["attribute_to_edit"], link_edits["new_value"])
 
             modes = mode_callback(arc)
             link = network.create_link(i_node, j_node, modes)
@@ -1409,31 +1431,31 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 link["@time_inter" + time] = link["time_inter" + src_time]
                 link["@toll" + time] = link["toll" + src_time]
 
-        # add check for network editor yaml file
-        # Check if network editor file is in inputs
-        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        network_editor_bool = False
-        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        if os.path.exists(network_editor_yaml_path):
-            network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-            with open(network_editor_yaml_path, "r") as stream:
-                network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
-        if network_editor_bool:
-            for link_edits in network_editor_data.get('traffic',[]):
-                if link_edits.get('delete_link', False):
-                    for ij in link_edits['i-j']:
-                        network.delete_link(ij[0], ij[1], cascade=True)
-                else:
-                    for link in network.links():
-                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
-                            #this format permits only one attribute change per edit
-                            #could explore using set_attribute_values() method in EMME API
-                            try:
-                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                            except KeyError: #one of two solutions should probably be removed
-                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
+        # # add check for network editor yaml file
+        # # Check if network editor file is in inputs
+        # network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        # network_editor_bool = False
+        # network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        # if os.path.exists(network_editor_yaml_path):
+        #     network_editor_bool = True
+        #     self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+        #     with open(network_editor_yaml_path, "r") as stream:
+        #         network_editor_data = yaml.safe_load(stream)
+        #         self._log.append({"type": "text", "content": "loaded YAML"})
+        # if network_editor_bool:
+        #     for link_edits in network_editor_data.get('traffic',[]):
+        #         if link_edits.get('delete_link', False):
+        #             for ij in link_edits['i-j']:
+        #                 network.delete_link(ij[0], ij[1], cascade=True)
+        #         else:
+        #             for link in network.links():
+        #                 if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
+        #                     #this format permits only one attribute change per edit
+        #                     #could explore using set_attribute_values() method in EMME API
+        #                     try:
+        #                         link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+        #                     except KeyError: #one of two solutions should probably be removed
+        #                         setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
 
 
         off_peak_factor_file = FILE_NAMES["OFF_PEAK"]

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -444,34 +444,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
         traffic_network = _network.Network()
         transit_network = _network.Network()
 
-
-        # add check for network editor yaml file
-        # Check if network editor file is in inputs
-        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        network_editor_bool = False
-        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        if os.path.exists(network_editor_yaml_path):
-            network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-            with open(network_editor_yaml_path, "r") as stream:
-                network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
-        if network_editor_bool:
-            for link_edits in network_editor_data.get('traffic',[]):
-                if link_edits.get('delete_link', False):
-                    for ij in link_edits['i-j']:
-                        traffic_network.delete_link(ij[0], ij[1], cascade=True)
-                else:
-                    for link in traffic_network.links():
-                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
-                            #this format permits only one attribute change per edit
-                            #could explore using set_attribute_values() method in EMME API
-                            try:
-                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                            except KeyError: #one of two solutions should probably be removed
-                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
-
-
         try:
             if self.traffic_scenario_id or self.merged_scenario_id:
                 for elem_type, attrs in traffic_attr_map.iteritems():
@@ -1325,6 +1297,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
         self._log.append({"type": "text", "content": "Import turns and turn restrictions complete"})
 
     def calc_traffic_attributes(self, network):
+
         self._log.append({"type": "header", "content": "Calculate derived traffic attributes"})
         # "COST":       "@cost_operating"
         # "ITOLL":      "@toll_flag"       # ITOLL  - Toll + 100 *[0,1] if managed lane (I-15 tolls)
@@ -1435,6 +1408,33 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
 
                 link["@time_inter" + time] = link["time_inter" + src_time]
                 link["@toll" + time] = link["toll" + src_time]
+
+        # add check for network editor yaml file
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "loaded YAML"})
+        if network_editor_bool:
+            for link_edits in network_editor_data.get('traffic',[]):
+                if link_edits.get('delete_link', False):
+                    for ij in link_edits['i-j']:
+                        traffic_network.delete_link(ij[0], ij[1], cascade=True)
+                else:
+                    for link in traffic_network.links():
+                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
+                            #this format permits only one attribute change per edit
+                            #could explore using set_attribute_values() method in EMME API
+                            try:
+                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                            except KeyError: #one of two solutions should probably be removed
+                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
+
 
         off_peak_factor_file = FILE_NAMES["OFF_PEAK"]
         if os.path.exists(_join(self.source, off_peak_factor_file)):

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -1478,27 +1478,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                     self._log.append({"type": "text", "content": msg})
                     self._error.append(msg)
 
-        # add check for network editor yaml file
-        # Check if network editor file is in inputs
-        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
-        network_editor_bool = False
-        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
-        if os.path.exists(network_editor_yaml_path):
-            network_editor_bool = True
-            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
-            with open(network_editor_yaml_path, "r") as stream:
-                network_editor_data = yaml.safe_load(stream)
-                self._log.append({"type": "text", "content": "loaded YAML"})
-        if network_editor_bool:
-            for link in network.links():
-                for link_edits in network_editor_data:
-                    if link["@tcov_id"] in link_edits["@tcov_id"]:
-                        #this format permits only one attribute change per edit
-                        try:
-                            link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                        except KeyError: #one of two solutions should probably be removed
-                            setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
-
         def lookup_link_name(link):
             for attr_name in ["#name", "#name_from", "#name_to"]:
                 for name, _factors in facility_factors.iteritems():
@@ -1654,6 +1633,33 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                     link["@cycle" + time] = link["cycle"]
                     link["@green_to_cycle" + time] = link["green_to_cycle"]
         self._log.append({"type": "text", "content": "Setting of time period @cycle and @green_to_cycle complete"})
+
+        # add check for network editor yaml file
+        # Check if network editor file is in inputs
+        network_editor_yaml_file = FILE_NAMES["NETWORK_EDITS"]
+        network_editor_bool = False
+        network_editor_yaml_path = _join(self.source, network_editor_yaml_file)
+        if os.path.exists(network_editor_yaml_path):
+            network_editor_bool = True
+            self._log.append({"type": "text", "content": "%s" % network_editor_yaml_path})
+            with open(network_editor_yaml_path, "r") as stream:
+                network_editor_data = yaml.safe_load(stream)
+                self._log.append({"type": "text", "content": "loaded YAML"})
+        if network_editor_bool:
+            for link_edits in network_editor_data.get('traffic',[]):
+                if link_edits.get('delete_link', False):
+                    for ij in link_edits['i-j']:
+                        network.delete_link(ij[0], ij[1], cascade=True)
+                else:
+                    for link in network.links():
+                        if link["@tcov_id"] in link_edits.get("@tcov_id",[]):
+                            #this format permits only one attribute change per edit
+                            #could explore using set_attribute_values() method in EMME API
+                            try:
+                                link[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                            except KeyError: #one of two solutions should probably be removed
+                                setattr(link, link_edits["attribute_to_edit"], link_edits["new_value"])
+
 
         network.delete_attribute("LINK", "green_to_cycle")
         network.delete_attribute("LINK", "cycle")

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -808,13 +808,14 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
 
             #arc edits to raw_network
             # if network_editor_bool:
-            for link_edits in network_editor_data.get('raw_network',[]):
-                if arc["HWYCOV-ID"] in link_edits.get("@tcov_id",[]):
-                    #could explore using set_attribute_values() method in EMME API
-                    try:
-                        arc[link_edits["attribute_to_edit"]] = link_edits["new_value"]
-                    except KeyError:
-                        setattr(arc, link_edits["attribute_to_edit"], link_edits["new_value"])
+            if arc_id_name == "HWYCOV-ID":
+                for link_edits in network_editor_data.get('raw_network',[]):
+                    if arc["HWYCOV-ID"] in link_edits.get("@tcov_id",[]):
+                        #could explore using set_attribute_values() method in EMME API
+                        try:
+                            arc[link_edits["attribute_to_edit"]] = link_edits["new_value"]
+                        except KeyError:
+                            setattr(arc, link_edits["attribute_to_edit"], link_edits["new_value"])
 
             modes = mode_callback(arc)
             link = network.create_link(i_node, j_node, modes)


### PR DESCRIPTION
Requires yaml file in scenario folder input directory named "network_edits.yaml"
YAML file needs to be structured like so:

- "@tcov_id": [8103] #can be one or multiple IDs!
  "descr": "23826-14275 - top link b4 Tierasanta"
  "attribute_to_edit": "modes"
  "new_value" : "dhHiI"

- "@tcov_id": [7772]
  "descr": "21928-13658 - bottom link b4 Tierasanta"
  "attribute_to_edit": "modes"
  "new_value" : "dhHiI"