### PR TITLE
Transit assignment parallelization

### DIFF
--- a/src/main/emme/toolbox/assignment/build_transit_scenario.py
+++ b/src/main/emme/toolbox/assignment/build_transit_scenario.py
@@ -163,7 +163,7 @@ class BuildTransitNetwork(_m.Tool(), gen_utils.Snapshot):
             root_dir = os.path.dirname(_m.Modeller().desktop.project.path)
             main_emmebank = _eb.Emmebank(os.path.join(root_dir, "Database", "emmebank"))
             base_scenario = main_emmebank.scenario(self.base_scenario_id)
-            transit_emmebank = _eb.Emmebank(os.path.join(root_dir, "Database_transit", "emmebank"))
+            transit_emmebank = _eb.Emmebank(os.path.join(root_dir, "Database_transit_" + self.period, "emmebank"))
             results = self(
                 self.period, base_scenario, transit_emmebank,
                 self.scenario_id, self.scenario_title,

--- a/src/main/emme/toolbox/export/export_data_loader_network.py
+++ b/src/main/emme/toolbox/export/export_data_loader_network.py
@@ -83,7 +83,7 @@ class ExportDataLoaderNetwork(_m.Tool(), gen_utils.Snapshot):
     main_directory = _m.Attribute(str)
     base_scenario_id = _m.Attribute(int)
     traffic_emmebank = _m.Attribute(str)
-    transit_emmebank = _m.Attribute(str)
+    # transit_emmebank = _m.Attribute(str)
     num_processors = _m.Attribute(str)
 
     tool_run_msg = ""
@@ -93,9 +93,10 @@ class ExportDataLoaderNetwork(_m.Tool(), gen_utils.Snapshot):
         self.main_directory = os.path.dirname(project_dir)
         self.base_scenario_id = 100
         self.traffic_emmebank = os.path.join(project_dir, "Database", "emmebank")
-        self.transit_emmebank = os.path.join(project_dir, "Database_transit", "emmebank")
+        # self.transit_emmebank = os.path.join(project_dir, "Database_transit", "emmebank")
+        self.transit_emmebank_dict = {}
         self.num_processors = "MAX-1"
-        self.attributes = ["main_directory", "base_scenario_id", "traffic_emmebank", "transit_emmebank", "num_processors"]
+        self.attributes = ["main_directory", "base_scenario_id", "traffic_emmebank", "num_processors"]
 
         self.container = gen_utils.DataLakeExporter().get_datalake_connection()
         self.guid = gen_utils.DataLakeExporter(ScenarioPath=self.main_directory).get_scenario_guid()
@@ -120,8 +121,8 @@ Export network results to csv files for SQL data loader."""
         pb.add_text_box('base_scenario_id', title="Base scenario ID:", size=10)
         pb.add_select_file('traffic_emmebank', 'file',
                            title='Select traffic emmebank')
-        pb.add_select_file('transit_emmebank', 'file',
-                           title='Select transit emmebank')
+        # pb.add_select_file('transit_emmebank', 'file',
+        #                    title='Select transit emmebank')
 
         dem_utils.add_select_processors("num_processors", pb, self)
 
@@ -131,7 +132,7 @@ Export network results to csv files for SQL data loader."""
         self.tool_run_msg = ""
         try:
             results = self(self.main_directory, self.base_scenario_id,
-                           self.traffic_emmebank, self.transit_emmebank,
+                           self.traffic_emmebank, self.transit_emmebank_dict,
                            self.num_processors)
             run_msg = "Export completed"
             self.tool_run_msg = _m.PageBuilder.format_info(run_msg)
@@ -141,10 +142,9 @@ Export network results to csv files for SQL data loader."""
             raise
 
     @_m.logbook_trace("Export network results for Data Loader", save_arguments=True)
-    def __call__(self, main_directory, base_scenario_id, traffic_emmebank, transit_emmebank, num_processors):
+    def __call__(self, main_directory, base_scenario_id, traffic_emmebank, transit_emmebank_dict, num_processors):
         attrs = {
             "traffic_emmebank": str(traffic_emmebank),
-            "transit_emmebank": str(transit_emmebank),
             "main_directory": main_directory,
             "base_scenario_id": base_scenario_id,
             "self": str(self)
@@ -154,7 +154,7 @@ Export network results to csv files for SQL data loader."""
         props = load_properties(os.path.join(main_directory, "conf", "sandag_abm.properties"))
 
         traffic_emmebank = _eb.Emmebank(traffic_emmebank)
-        transit_emmebank = _eb.Emmebank(transit_emmebank)
+        # transit_emmebank = _eb.Emmebank(transit_emmebank)
         if not os.path.exists(os.path.join(main_directory, "report")):
             os.mkdir(os.path.join(main_directory, "report"))
         export_path = os.path.join(main_directory, "report")
@@ -168,7 +168,7 @@ Export network results to csv files for SQL data loader."""
 
         self.export_traffic_attribute(base_scenario, export_path, traffic_emmebank, period_scenario_ids, props)
         self.export_traffic_load_by_period(export_path, traffic_emmebank, period_scenario_ids)
-        self.export_transit_results(export_path, input_path, transit_emmebank, period_scenario_ids, num_processors)
+        self.export_transit_results(export_path, input_path, transit_emmebank_dict, period_scenario_ids, num_processors)
         self.export_geometry(export_path, traffic_emmebank)
 
     @_m.logbook_trace("Export traffic attribute data")
@@ -504,7 +504,7 @@ Export network results to csv files for SQL data loader."""
             self.util_DataLakeExporter.write_to_datalake({os.path.basename(filename)[:-4]:str(filename)})
 
     @_m.logbook_trace("Export transit results")
-    def export_transit_results(self, export_path, input_path, transit_emmebank, period_scenario_ids, num_processors):
+    def export_transit_results(self, export_path, input_path, transit_emmebank_dict, period_scenario_ids, num_processors):
         # Note: Node analysis for transfers is VERY time consuming
         #       this implementation will be replaced when new Emme version is available
 
@@ -615,7 +615,7 @@ Export network results to csv files for SQL data loader."""
             premium_modes = ["c", "l", "e", "p", "r", "y", "o", "w", "x", "k", "u", "f", "g", "q", "j", "Q", "J"]
             for tod, scen_id in period_scenario_ids.iteritems():
                 with _m.logbook_trace("Processing period %s" % tod):
-                    scenario = transit_emmebank.scenario(scen_id)
+                    scenario = transit_emmebank_dict[tod].scenario(scen_id)
                     with _m.logbook_trace("Scen %s" % (scenario)):
                     # attributes
                         total_walk_flow = create_attribute("LINK", "@volax", "total walk flow on links",

--- a/src/main/emme/toolbox/import/import_transit_demand.py
+++ b/src/main/emme/toolbox/import/import_transit_demand.py
@@ -117,18 +117,18 @@ class ImportMatrices(_m.Tool(), gen_utils.Snapshot):
             raise
 
     @_m.logbook_trace("Create TOD transit trip tables", save_arguments=True)
-    def __call__(self, output_dir, scenario):
+    def __call__(self, output_dir, scenario_dict):
         attributes = {"output_dir": output_dir}
         gen_utils.log_snapshot("Sum demand", str(self), attributes)
 
-        self.scenario = scenario
+        self.scenario_dict = scenario_dict
         self.output_dir = output_dir
         self.import_transit_trips()
 
     @_m.logbook_trace("Import ActivitySim transit trips from OMX")
     def import_transit_trips(self):
-        emmebank = self.scenario.emmebank
-        emme_zones = self.scenario.zone_numbers
+        # emmebank = self.scenario.emmebank
+        # emme_zones = self.scenario.zone_numbers
         matrix_name_tmplts = [
             ("mf%s_%s_LOC", "%s_%s_set1_%s"),
             ("mf%s_%s_PRM", "%s_%s_set2_%s"),
@@ -147,6 +147,8 @@ class ImportMatrices(_m.Tool(), gen_utils.Snapshot):
         with gen_utils.OMXManager(self.output_dir, "tran%sTrips%s.omx") as omx_manager:
             for period, matrix_name, omx_key in matrix_names:
                 logbook_label = "Report on import from OMX key %s to matrix %s" % (omx_key %"SET", matrix_name)
+
+                emmebank = self.scenario_dict[period[1:]].emmebank
                 
                 #add both KNR_SET and TNC_SET into KNR
                 # if ("KNR" in matrix_name):
@@ -198,7 +200,7 @@ class ImportMatrices(_m.Tool(), gen_utils.Snapshot):
                 #     expanded_matrix_data = matrix_data.expand([emme_zones, emme_zones])
                 #     matrix.set_data(expanded_matrix_data, self.scenario)
                 # else:
-                matrix.set_numpy_data(total_asim_demand, self.scenario)
+                matrix.set_numpy_data(total_asim_demand, self.scenario_dict[period[1:]])
                     
                 # if ("KNR" in matrix_name):
                 #     dem_utils.demand_report([
@@ -227,4 +229,4 @@ class ImportMatrices(_m.Tool(), gen_utils.Snapshot):
                     ("airport_demand", airport_demand), 
                     ("visitor_demand", visitor_demand), 
                     ("total_asim_demand", total_asim_demand)
-                ], logbook_label, self.scenario)
+                ], logbook_label, self.scenario_dict[period[1:]])

--- a/src/main/emme/toolbox/initialize/initialize_transit_database.py
+++ b/src/main/emme/toolbox/initialize/initialize_transit_database.py
@@ -104,7 +104,7 @@ class InitializeTransitDatabase(_m.Tool(), gen_utils.Snapshot):
             raise
 
     @_m.logbook_trace('Initialize transit database', save_arguments=True)
-    def __call__(self, base_scenario, add_database=True):
+    def __call__(self, base_scenario, period, add_database=True):
         attributes = {"base_scenario": base_scenario.id}
         gen_utils.log_snapshot("Initialize transit database", str(self), attributes)
         create_function = _m.Modeller().tool("inro.emme.data.function.create_function")
@@ -117,7 +117,7 @@ class InitializeTransitDatabase(_m.Tool(), gen_utils.Snapshot):
         props = load_properties(os.path.join(main_directory, "conf", "sandag_abm.properties"))
         scenarioYear = props["scenarioYear"]
 
-        transit_db_dir = join(project_dir, "Database_transit")
+        transit_db_dir = join(project_dir, "Database_transit_" + period)
         transit_db_path = join(transit_db_dir, "emmebank")
         network = base_scenario.get_partial_network(["NODE"], include_attributes=True)
         #num_zones = sum([1 for n in network.nodes() if n["isZone"] > 0])
@@ -137,7 +137,7 @@ class InitializeTransitDatabase(_m.Tool(), gen_utils.Snapshot):
         else:
             transit_eb = _eb.create(transit_db_path, dimensions)
 
-        transit_eb.title = base_eb.title[:65] + "-transit"
+        transit_eb.title = base_eb.title[:65] + "-transit-" + period
         transit_eb.coord_unit_length = base_eb.coord_unit_length
         transit_eb.unit_of_length = base_eb.unit_of_length
         transit_eb.unit_of_cost = base_eb.unit_of_cost

--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -87,6 +87,8 @@ import pyodbc
 import win32com.client as win32
 import shutil
 
+import multiprocessing
+
 _join = os.path.join
 _dir = os.path.dirname
 _norm = os.path.normpath
@@ -424,33 +426,34 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 		#     f.write("Num Select links {}\nExtra Attribute Value {}".format(num_select_links,extra_attribute_values))
         # f.close()
 
-        if os.path.exists(_join(self._path, "emme_project", "Database_transit", "emmebank")):
-            with _eb.Emmebank(_join(self._path, "emme_project", "Database_transit", "emmebank")) as transit_db:
-                transit_db_dims = transit_db.dimensions
-                num_nodes = transit_db_dims["regular_nodes"] + transit_db_dims['centroids']
-                num_links = transit_db_dims["links"]
-                num_turn_entries = transit_db_dims["turn_entries"]
-                num_transit_lines = transit_db_dims['transit_lines']
-                num_transit_segments = transit_db_dims['transit_segments']
-                num_traffic_classes = 15
-
-                extra_attribute_values = 18000000
-                extra_attribute_values += (num_nodes + 1) * additional_node_extra_attributes
-                extra_attribute_values += (num_links + 1) * additional_link_extra_attributes
-                extra_attribute_values += (num_transit_lines + 1)* additional_line_extra_attributes
-                extra_attribute_values += (num_transit_segments + 1) * additional_segment_extra_attributes
-
-                if num_select_links > 3:
-                    extra_attribute_values += 18000000 + (num_select_links - 3) * ((num_links + 1) * (num_traffic_classes + 1) + (num_turn_entries + 1) * (num_traffic_classes))
-
-                if extra_attribute_values > transit_db_dims["extra_attribute_values"] or transit_db_dims["full_matrices"] < 9999:
-                    transit_db_dims["extra_attribute_values"] = extra_attribute_values
-                    transit_db_dims["full_matrices"] = 9999
-                    #change_dimensions(emmebank_dimensions=transit_db_dims, emmebank=transit_db, keep_backup=False)
-                    #replaced the above line with the below lines - suggested by Antoine, Bentley (2022-06-02)
-                    if transit_db.scenario(1) is None:
-                        transit_db.create_scenario(1)
-                    change_dimensions(transit_db_dims, transit_db, False)
+        for period in periods:
+            if os.path.exists(_join(self._path, "emme_project", "Database_transit_" + period, "emmebank")):
+                with _eb.Emmebank(_join(self._path, "emme_project", "Database_transit_" + period, "emmebank")) as transit_db:
+                    transit_db_dims = transit_db.dimensions
+                    num_nodes = transit_db_dims["regular_nodes"] + transit_db_dims['centroids']
+                    num_links = transit_db_dims["links"]
+                    num_turn_entries = transit_db_dims["turn_entries"]
+                    num_transit_lines = transit_db_dims['transit_lines']
+                    num_transit_segments = transit_db_dims['transit_segments']
+                    num_traffic_classes = 15
+                    
+                    extra_attribute_values = 18000000 
+                    extra_attribute_values += (num_nodes + 1) * additional_node_extra_attributes
+                    extra_attribute_values += (num_links + 1) * additional_link_extra_attributes
+                    extra_attribute_values += (num_transit_lines + 1)* additional_line_extra_attributes 
+                    extra_attribute_values += (num_transit_segments + 1) * additional_segment_extra_attributes
+                    
+                    if num_select_links > 3:
+                        extra_attribute_values += 18000000 + (num_select_links - 3) * ((num_links + 1) * (num_traffic_classes + 1) + (num_turn_entries + 1) * (num_traffic_classes))
+                        
+                    if extra_attribute_values > transit_db_dims["extra_attribute_values"] or transit_db_dims["full_matrices"] < 9999:
+                        transit_db_dims["extra_attribute_values"] = extra_attribute_values
+                        transit_db_dims["full_matrices"] = 9999 
+                        #change_dimensions(emmebank_dimensions=transit_db_dims, emmebank=transit_db, keep_backup=False)
+                        #replaced the above line with the below lines - suggested by Antoine, Bentley (2022-06-02)
+                        if transit_db.scenario(1) is None:
+                            transit_db.create_scenario(1)
+                        change_dimensions(transit_db_dims, transit_db, False)
 
         with _m.logbook_trace("Setup and initialization"):
             self.set_global_logbook_level(props)
@@ -542,15 +545,21 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         traffic_components.append("traffic_demand")
                     init_matrices(traffic_components, periods, base_scenario, deleteAllMatrices)
 
-                    transit_scenario = init_transit_db(base_scenario, add_database=not useLocalDrive)
-                    transit_emmebank = transit_scenario.emmebank
-                    transit_components = ["transit_skims"]
-                    if not skipCopyWarmupTripTables:
-                        transit_components.append("transit_demand")
-                    init_matrices(transit_components, periods, transit_scenario, deleteAllMatrices)
+                    transit_scenario_dict = {}
+                    transit_emmebank_dict = {}
+                    for period in periods:
+                        transit_scenario_dict[period] = init_transit_db(base_scenario, period, add_database=not useLocalDrive)
+                        transit_emmebank_dict[period] = transit_scenario_dict[period].emmebank
+                        transit_components = ["transit_skims"]
+                        if not skipCopyWarmupTripTables:
+                            transit_components.append("transit_demand")
+                        init_matrices(transit_components, [period], transit_scenario_dict[period], deleteAllMatrices)
                 else:
-                    transit_emmebank = _eb.Emmebank(_join(self._path, "emme_project", "Database_transit", "emmebank"))
-                    transit_scenario = transit_emmebank.scenario(base_scenario.number)
+                    transit_scenario_dict = {}
+                    transit_emmebank_dict = {}
+                    for period in periods:
+                        transit_emmebank_dict[period] = _eb.Emmebank(_join(self._path, "emme_project", "Database_transit_" + period, "emmebank"))
+                        transit_scenario_dict[period] = transit_emmebank_dict[period].scenario(base_scenario.number)
 
                 if not skipCopyWarmupTripTables:
                     # import seed auto demand and seed truck demand
@@ -567,8 +576,11 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 
             else:
                 base_scenario = main_emmebank.scenario(scenario_id)
-                transit_emmebank = _eb.Emmebank(_join(self._path, "emme_project", "Database_transit", "emmebank"))
-                transit_scenario = transit_emmebank.scenario(base_scenario.number)
+                transit_scenario_dict = {}
+                transit_emmebank_dict = {}
+                for period in periods:
+                    transit_emmebank_dict[period] = _eb.Emmebank(_join(self._path, "emme_project", "Database_transit_" + period, "emmebank"))
+                    transit_scenario_dict[period] = transit_emmebank_dict[period].scenario(base_scenario.number)
 
             # Check that setup files were generated
             # self.run_proc("CheckOutput.bat", [drive + path_no_drive, 'Setup'], "Check for outputs")
@@ -599,7 +611,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                             src_period_scenario = main_emmebank.scenario(number)
                             transit_assign_scen = build_transit_scen(
                                period=period, base_scenario=src_period_scenario,
-                               transit_emmebank=transit_emmebank,
+                               transit_emmebank=transit_emmebank_dict[period],
                                scenario_id=src_period_scenario.id,
                                scenario_title="%s %s transit assign" % (base_scenario.title, period),
                                data_table_name=scenarioYear, overwrite=True)
@@ -616,14 +628,14 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         # Run transit assignment in separate process
                         # Running in same process slows OMX skim export for unknown reason
                         # transit_emmebank need to be closed and re-opened to be accessed by separate process
-                        transit_emmebank = self.run_transit_assignments(transit_emmebank, scenarioYear)
-                        _m.Modeller().desktop.refresh_data()
+                        transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, export_transit_skims)
+                        # _m.Modeller().desktop.refresh_data()
 
-                        #output transit skims by period
-                        for number, period in period_ids:
-                            transit_scenario = transit_emmebank.scenario(number)
-                            omx_file = _join(output_dir, "skims", "transit_skims_" + period + ".omx")
-                            export_transit_skims(omx_file, [period], transit_scenario, big_to_zero=False)
+                        # #output transit skims by period
+                        # for number, period in period_ids:
+                        #     transit_scenario = transit_emmebank.scenario(number)
+                        #     omx_file = _join(output_dir, "skims", "transit_skims_" + period + ".omx")
+                        #     export_transit_skims(omx_file, [period], transit_scenario, big_to_zero=False)
 
                 if not skipTransponderExport[iteration]:
                     am_scenario = main_emmebank.scenario(base_scenario.number + 2)
@@ -695,14 +707,14 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                     num_processors, select_link, makeFinalHighwayAssignmentStochastic, input_dir)
 
         if not skipFinalTransitAssignment:
-            import_transit_demand(output_dir + '/assignment', transit_scenario)
+            import_transit_demand(output_dir + '/assignment', transit_scenario_dict)
             with _m.logbook_trace("Final transit assignments"):
                 # Final iteration includes the transit skims per ABM-1072
                 for number, period in period_ids:
                     src_period_scenario = main_emmebank.scenario(number)
                     transit_assign_scen = build_transit_scen(
                         period=period, base_scenario=src_period_scenario,
-                        transit_emmebank=transit_emmebank,
+                        transit_emmebank=transit_emmebank_dict[period],
                         scenario_id=src_period_scenario.id,
                         scenario_title="%s %s transit assign" % (base_scenario.title, period),
                         data_table_name=scenarioYear, overwrite=True)
@@ -713,14 +725,14 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 # Run transit assignment in separate process
                 # Running in same process slows OMX skim export for unknown reason
                 # transit_emmebank need to be closed and re-opened to be accessed by separate process
-                transit_emmebank = self.run_transit_assignments(transit_emmebank, scenarioYear)
-                _m.Modeller().desktop.refresh_data()
+                transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, export_transit_skims)
+                # _m.Modeller().desktop.refresh_data()
 
-                #output transit skims by period
-                for number, period in period_ids:
-                    transit_scenario = transit_emmebank.scenario(number)
-                    omx_file = _join(output_dir, "skims", "transit_skims_" + period + ".omx")
-                    export_transit_skims(omx_file, [period], transit_scenario, big_to_zero=False)
+                # #output transit skims by period
+                # for number, period in period_ids:
+                #     transit_scenario = transit_emmebank.scenario(number)
+                #     omx_file = _join(output_dir, "skims", "transit_skims_" + period + ".omx")
+                #     export_transit_skims(omx_file, [period], transit_scenario, big_to_zero=False)
 
         # if not skipTransitShed:
         #     # write walk and drive transit sheds
@@ -736,8 +748,8 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         if not skipDataExport:
             # export network and matrix results from Emme directly to T if using local drive
             output_directory = _join(self._path, "output")
-            export_network_data(self._path, scenario_id, main_emmebank, transit_emmebank, num_processors)
-            export_matrix_data(output_directory, base_scenario, transit_scenario)
+            export_network_data(self._path, scenario_id, main_emmebank, transit_emmebank_dict, num_processors)
+            export_matrix_data(output_directory, base_scenario, transit_scenario_dict["EA"])
             # export core ABM data
             # Note: uses relative project structure, so cannot redirect to T drive
             # self.run_proc("DataExporter.bat", [drive, path_no_drive], "Export core ABM data",capture_output=True)
@@ -811,8 +823,9 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
             drive, path_no_drive = os.path.splitdrive(self._path)
             # self._path = main_directory
             # drive, path_no_drive = os.path.splitdrive(self._path)
-            init_transit_db.add_database(
-                _eb.Emmebank(_join(main_directory, "emme_project", "Database_transit", "emmebank")))
+            for period in periods:
+                init_transit_db.add_database(
+                    _eb.Emmebank(_join(main_directory, "emme_project", "Database_transit_" + period, "emmebank")))
 
         if not skipDataLoadRequest:
             start_db_time = datetime.datetime.now()  # record the time to search for request id in the load request table, YMA, 1/23/2019
@@ -848,60 +861,84 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         except KeyError:
             raise Exception("properties.RunModel.LogLevel: value must be one of %s" % ",".join(log_states.keys()))
 
-    def run_transit_assignments(self, transit_emmebank, scenarioYear):
+    def run_transit_assignments(self, transit_emmebank_dict, scenarioYear, output_dir, export_transit_skims):
 
-        transit_emmebank_path = transit_emmebank.path
-        emme_project_dir = _dir(_dir(transit_emmebank_path))
-        main_directory = _dir(emme_project_dir)
+        scenario_id = 100
+        periods = ["EA", "AM", "MD", "PM", "EV"]
+        period_ids = list(enumerate(periods, start=int(scenario_id) + 1))
 
+        transit_processors = (multiprocessing.cpu_count() - 1) // 5
 
-        if os.path.exists(_join(emme_project_dir, "transit_assign_dummy_project")):
-            shutil.rmtree(_join(emme_project_dir, "transit_assign_dummy_project"))
-        project_path = _app.create_project(emme_project_dir, "transit_assign_dummy_project")
-        dummy_desktop = _app.start_dedicated(visible=False, user_initials="SD", project=project_path)
-        dummy_desktop.add_modeller_toolbox(_join(main_directory, "emme_project", "Scripts", "sandag_toolbox.mtbx"))
-        data_explorer = dummy_desktop.data_explorer()
-        db = data_explorer.add_database(transit_emmebank.path)
-        db.open()
+        transit_emmebank_path_dict = {}
 
-        project_table_db = _m.Modeller().desktop.project.data_tables()
-        data = project_table_db.table("%s_transit_passes" % scenarioYear).get_data()
-        dummy_project_table_db = dummy_desktop.project.data_tables()
-        dummy_project_table_db.create_table("%s_transit_passes" % scenarioYear, data, overwrite=True)
+        processes = []
 
-        dummy_desktop.project.save()
-        dummy_desktop.close()
-        transit_emmebank.dispose()
-
-        _time.sleep(2)
         with _m.logbook_trace("Running all period transit assignmens"):
-            report = _m.PageBuilder(title="Command report")
-            script = _join(main_directory, "python", "emme", "run_transit_assignment.py")
-            err_file_ref, err_file_path = _tempfile.mkstemp(suffix='.log')
-            err_file = os.fdopen(err_file_ref, "w")
-            try:
-                output = _subprocess.check_output(
-                    [sys.executable, script, "--root_dir", '"%s"' % main_directory, "--project_path", '"%s"' % project_path],
-                    stderr=err_file, shell=True)
-                self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % output)
-            except _subprocess.CalledProcessError as error:
-                self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % error.output)
-                raise
-            finally:
-                err_file.close()
-                with open(err_file_path, 'r') as f:
-                    error_msg = f.read()
-                os.remove(err_file_path)
-                if error_msg:
-                    self.add_html(report, 'Error message(s):<br><br><div class="preformat">%s</div>' % error_msg)
-                _m.logbook_write("Transit assignment process record", report.render())
-        _time.sleep(2)
+            for number, period in period_ids:
 
-        # NOTE: could remove project when done
-        #shutil.rmtree(project_dir)
-        # NOTE: need to pass back re-opened objects
-        transit_emmebank = _eb.Emmebank(transit_emmebank_path)
-        return transit_emmebank
+                transit_emmebank_path_dict[period] = transit_emmebank_dict[period].path
+                emme_project_dir = _dir(_dir(transit_emmebank_path_dict[period]))
+                main_directory = _dir(emme_project_dir)
+
+                if os.path.exists(_join(emme_project_dir, "transit_assign_dummy_project_" + period)):
+                    shutil.rmtree(_join(emme_project_dir, "transit_assign_dummy_project_" + period))
+                project_path = _app.create_project(emme_project_dir, "transit_assign_dummy_project_" + period)
+                dummy_desktop = _app.start_dedicated(visible=False, user_initials="SD", project=project_path)
+                dummy_desktop.add_modeller_toolbox(_join(main_directory, "emme_project", "Scripts", "sandag_toolbox.mtbx"))
+                data_explorer = dummy_desktop.data_explorer()
+                db = data_explorer.add_database(transit_emmebank_dict[period].path)
+                db.open()
+
+                project_table_db = _m.Modeller().desktop.project.data_tables()
+                data = project_table_db.table("%s_transit_passes" % scenarioYear).get_data()
+                dummy_project_table_db = dummy_desktop.project.data_tables()
+                dummy_project_table_db.create_table("%s_transit_passes" % scenarioYear, data, overwrite=True)
+
+                dummy_desktop.project.save()
+                dummy_desktop.close()
+                transit_emmebank_dict[period].dispose()
+
+                _time.sleep(2)
+                
+                script = _join(main_directory, "python", "emme", "run_transit_assignment.py")
+                err_file_ref, err_file_path = _tempfile.mkstemp(suffix='.log')
+                err_file = os.fdopen(err_file_ref, "w")
+                p = _subprocess.Popen(
+                    [sys.executable, script, "--root_dir", '"%s"' % main_directory, "--project_path", '"%s"' % project_path,
+                    "--period", '"%s"' % period, "--number", '"%s"' % number, "--proc", '"%s"' % transit_processors], 
+                    stderr=err_file, shell=True)
+                processes.append({
+                    "p": p,
+                    "period": period
+                })
+                _time.sleep(2)
+
+                # NOTE: could remove project when done
+                #shutil.rmtree(project_dir)
+                # NOTE: need to pass back re-opened objects
+
+            for p in processes:
+                report = _m.PageBuilder(title="Command report")
+                out, err = p["p"].communicate()
+                self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % out)
+                if err:
+                    self.add_html(report, 'Error message(s):<br><br><div class="preformat">%s</div>' % err)
+                _m.logbook_write("Transit assignment process record for period " + p["period"], report.render()) 
+                if p["p"].returncode != 0:
+                    raise
+
+
+        transit_emmebank_dict = {}
+        for number, period in period_ids:
+
+            transit_emmebank_dict[period] = _eb.Emmebank(transit_emmebank_path_dict[period])
+            # return transit_emmebank
+            _m.Modeller().desktop.refresh_data()  
+            transit_scenario = transit_emmebank_dict[period].scenario(number)
+            omx_file = _join(output_dir, "skims", "transit_skims_" + period + ".omx")
+            export_transit_skims(omx_file, [period], transit_scenario, big_to_zero=False)
+        
+        return transit_emmebank_dict
 
     def run_traffic_assignments(self, base_scenario, period_ids, msa_iteration, relative_gap,
                                 max_assign_iterations, num_processors, select_link=None,

--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -229,7 +229,11 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
         # create new emmebanks and copy emmebank data to local drive
         import_from_db = _m.Modeller().tool("inro.emme.data.database.import_from_database")
         emmebank_paths = []
-        for db_dir in ["Database", "Database_transit"]:
+        periods = ["EA", "AM", "MD", "PM", "EV"]
+        dbs = ["Database"]
+        for period in periods:
+            dbs.append("Database_transit_" + period)
+        for db_dir in dbs:
             src_db_path = _join(src, "emme_project", db_dir, "emmebank")
             if not os.path.exists(src_db_path):
                 # skip if the database does not exist (will be created later)

--- a/src/main/emme/toolbox/utilities/run_summary.py
+++ b/src/main/emme/toolbox/utilities/run_summary.py
@@ -348,10 +348,6 @@ class RunTime(_m.Tool()):
     def add_runtimes(self, final_runtimes, runtimes, prefix, suffix, step_dict, prev_step, attrs, depth):
         index_dict = {}
         for index, info in enumerate(runtimes):
-            if info[1] == 'Final traffic assignments':
-                prev_step = self.add_runtimes(final_runtimes, [[0, 'Iteration 4', 0]], prefix, suffix, step_dict, prev_step, attrs, 0)
-                prefix = '  -  ' + prefix
-                suffix = suffix + '___Iteration 4'
 
             temp_info = info[1]
             
@@ -382,5 +378,10 @@ class RunTime(_m.Tool()):
             elif depth > 0:
                 child_runtimes = self.get_child_runtimes(info[0], attrs)
                 prev_step = self.add_runtimes(final_runtimes, child_runtimes, '  -  ' + prefix, suffix + '___' + info[1], step_dict, prev_step, attrs, depth - 1)
+            
+            if temp_info == 'Iteration 3':
+                prev_step = self.add_runtimes(final_runtimes, [[0, 'Iteration 4', 0]], prefix, suffix, step_dict, prev_step, attrs, 0)
+                prefix = '  -  ' + prefix
+                suffix = suffix + '___Iteration 4'
             
         return prev_step

--- a/src/main/emme/toolbox/validation/validation.py
+++ b/src/main/emme/toolbox/validation/validation.py
@@ -90,7 +90,7 @@ Export traffic flow to Excel files for base year validation."""
         traffic_emmebank = _eb.Emmebank(traffic_emmebank)
         #transit_emmebank = _eb.Emmebank(transit_emmebank)
         export_path = os.path.join(main_directory, "analysis/validation")
-        transitbank_path = os.path.join(main_directory, "emme_project/Database_transit/emmebank")
+        # transitbank_path = os.path.join(main_directory, "emme_project/Database_transit/emmebank")
         source_file = os.path.join(export_path, "source_EMME.xlsx")
         df = pd.read_excel(source_file, header=None, sheet_name='raw')
         writer = pd.ExcelWriter(source_file, engine='openpyxl')
@@ -148,24 +148,34 @@ Export traffic flow to Excel files for base year validation."""
         desktop = _m.Modeller().desktop
         data_explorer = desktop.data_explorer()
 
-        try:
-            data_explorer.add_database(transitbank_path)
-        except:
-            pass  #if transit database already included in the project
-        all_databases = data_explorer.databases()
-        for database in all_databases:
-            if "transit" in database.name():
-                database.open()
-                break
+        # try:
+        #     data_explorer.add_database(transitbank_path)
+        # except:
+        #     pass  #if transit database already included in the project
+        # all_databases = data_explorer.databases()
+        # for database in all_databases:
+        #     if "transit" in database.name():
+        #         database.open()
+        #         break
         for p, scen_id in period_scenario_ids.iteritems():
+            try:
+                data_explorer.add_database(os.path.join(main_directory, "emme_project", "Database_transit_" + p, "emmebank"))
+            except:
+                pass  #if transit database already included in the project
+            all_databases = data_explorer.databases()
+            for database in all_databases:
+                if ("transit-" + p) in database.name():
+                    database.open()
+                    break
             scen = database.scenario_by_number(scen_id)
             data_explorer.replace_primary_scenario(scen)
             self.export_transit(export_path, desktop, p)
+            # -----------------close or remove transit databack from the project-----------------
+            database.close()
+            if "T:" not in main_directory:
+                data_explorer.remove_database(database)
 
-        # -----------------close or remove transit databack from the project-----------------
-        database.close()
-        if "T:" not in main_directory:
-            data_explorer.remove_database(database)
+
         all_databases = data_explorer.databases()
         for database in all_databases:
             if "transit" not in database.name():

--- a/src/main/python/emme/run_transit_assignment.py
+++ b/src/main/python/emme/run_transit_assignment.py
@@ -16,32 +16,38 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-r", "--root_dir")
     parser.add_argument("-p", "--project_path")
+    parser.add_argument("--number")
+    parser.add_argument("--period")
+    parser.add_argument("--proc")
     args = parser.parse_args()
     print(args)
     main_directory = args.root_dir.strip('"')
     project_path = args.project_path.strip('"')
+    number = args.number.strip('"')
+    period = args.period.strip('"')
+    num_processors = str(args.proc.strip('"'))
     print(main_directory, project_path)
     desktop = _app.start_dedicated(visible=True, user_initials="SD", project=project_path)
     modeller = _m.Modeller(desktop)
     
-    with _m.logbook_trace("Running all period transit assignmens"):
+    with _m.logbook_trace("Running transit assignment for period " + period):
         transit_assign  = modeller.tool("sandag.assignment.transit_assignment")
         load_properties = modeller.tool('sandag.utilities.properties')
 
         props = load_properties(os.path.join(main_directory, "conf", "sandag_abm.properties"))
-        scenario_id = 100
+        # scenario_id = 100
 
-        transit_emmebank = _eb.Emmebank(os.path.join(main_directory, "emme_project", "Database_transit", "emmebank"))
+        transit_emmebank = _eb.Emmebank(os.path.join(main_directory, "emme_project", "Database_transit_" + period, "emmebank"))
 
-        periods = ["EA", "AM", "MD", "PM", "EV"]
-        period_ids = list(enumerate(periods, start=int(scenario_id) + 1))
-        num_processors = "MAX-1"
+        # periods = ["EA", "AM", "MD", "PM", "EV"]
+        # period_ids = list(enumerate(periods, start=int(scenario_id) + 1))
+        # num_processors = "9"
         scenarioYear = str(props["scenarioYear"])
 
-        for number, period in period_ids:
-            transit_assign_scen = transit_emmebank.scenario(number)
-            transit_assign(period, transit_assign_scen, data_table_name=scenarioYear,
-                           skims_only=True, num_processors=num_processors)
+        # for number, period in period_ids:
+        transit_assign_scen = transit_emmebank.scenario(number)
+        transit_assign(period, transit_assign_scen, data_table_name=scenarioYear,
+                       skims_only=True, num_processors=num_processors)
 
         transit_emmebank.dispose()
     desktop.close()


### PR DESCRIPTION
Fixes AB#418

Runs transit assignment for all 5 periods in parallel. This requires creating a separate Emmebank and project for each time period. Time savings is about 2.5 hours per iteration, about 10 hours for a full run.

Some Emme tools have had their parameters altered but have not had their toolbox pages updated. These tools will not work if ran directly from the toolbox but will work when called from the master run. I will update the toolbox pages soon to fix this.