### PR TITLE
Add connector creation and OMX export to transit parallelization

### DIFF
--- a/src/main/emme/toolbox/assignment/create_transit_connector.py
+++ b/src/main/emme/toolbox/assignment/create_transit_connector.py
@@ -195,7 +195,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_u" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_u" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)
                 create_connectors(access_modes=["f"],
                                 egress_modes=["g"],
@@ -212,7 +212,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_f" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_f" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)                     
                 create_connectors(access_modes=["q"],
                                 egress_modes=["j"],
@@ -229,7 +229,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_q" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_q" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario) 
                 create_connectors(access_modes=["Q"],
                                 egress_modes=["J"],
@@ -246,7 +246,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_Q" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_Q" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)                     
                 create_connectors(access_modes=["u", "q", "Q"],
                                 egress_modes=["k", "j", "J"],
@@ -277,7 +277,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_uqQ" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_uqQ" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)                       
                 create_connectors(access_modes=["f", "q", "Q"],
                                 egress_modes=["g", "j", "J"],
@@ -294,7 +294,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_fqQ" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_fqQ" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)
                 create_connectors(access_modes=["q", "Q"],
                                 egress_modes=["j", "J"],
@@ -311,7 +311,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_qQ" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_qQ" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)       
                 create_connectors(access_modes=["u", "f", "q", "Q"],
                                 egress_modes=["k", "g", "j", "J"],
@@ -341,14 +341,14 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
                                 scenario=self.scenario)
                 export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                             "node": 'none'},
-                            export_file = "connectors_ufqQ" + self.line_haul_modes[i] + ".out",
+                            export_file = period + "_connectors_ufqQ" + self.line_haul_modes[i] + ".out",
                             field_separator = " ", scenario=self.scenario)
 
             # import connectors; if a connector already exists, it's skipped because the connector with the most access modes is imported first
             for line_haul in self.line_haul_modes:
                 for acc in self.acc_modes:
-                    print("temp/" + "connectors_" + acc + line_haul + ".out")
-                    import_basenet(transaction_file = "connectors_" + acc + line_haul + ".out", revert_on_error = False, scenario=self.scenario)
+                    print("temp/" + period + "_connectors_" + acc + line_haul + ".out")
+                    import_basenet(transaction_file = period + "_connectors_" + acc + line_haul + ".out", revert_on_error = False, scenario=self.scenario)
             # export all connectors
             export_basenet(selection = {"link": 'i=1,4947 or j=1,4947',
                                         "node": 'none'},
@@ -358,7 +358,7 @@ class CreateTransitConnector(_m.Tool(), gen_utils.Snapshot):
             for line_haul in self.line_haul_modes:
                 for acc in self.acc_modes:
                     try:
-                        os.remove("connectors_" + acc + line_haul + ".out")
+                        os.remove(period + "_connectors_" + acc + line_haul + ".out")
                     except:
                         pass
 

--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -264,7 +264,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         file_manager = modeller.tool("sandag.utilities.file_manager")
         utils = modeller.module('sandag.utilities.demand')
         load_properties = modeller.tool('sandag.utilities.properties')
-        # run_summary = modeller.tool("sandag.utilities.run_summary")
+        run_summary = modeller.tool("sandag.utilities.run_summary")
 
         self.username = username
         self.password = password
@@ -846,7 +846,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                     _join(output_dir, "iter%s" % (msa_iteration)))
 
         # record run time
-        # run_summary(path=self._path)
+        run_summary(path=self._path)
 
     def set_global_logbook_level(self, props):
         self._log_level = props.get("RunModel.LogbookLevel", "ENABLED")

--- a/src/main/emme/toolbox/utilities/run_summary.py
+++ b/src/main/emme/toolbox/utilities/run_summary.py
@@ -64,7 +64,9 @@ class RunTime(_m.Tool()):
         :param path: Scenario file path
         """
 
-        if self.runtime_depth is None:
+        # Depth 1 shows runtime for sub-steps, depth 2 shows sub-sub-steps, etc.
+        # Default to 0
+        if (not hasattr(self, 'runtime_depth')) or self.runtime_depth is None:
             self.runtime_depth = 0
 
         # Get element IDs for model runs


### PR DESCRIPTION
Fixes [AB#431](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/431)

Minor additional runtime savings by adding additional transit assignment steps to parallelization. Saves about 1 hour in iteration 1 for transit connector creation, and about 0.5 hours per iteration in OMX skim export. Overall time savings for a full run should be around 3 hours.