### PR TITLE
Add auto operating cost adjustment after vehicle type choice

### DIFF
--- a/src/asim/configs/resident/settings.yaml
+++ b/src/asim/configs/resident/settings.yaml
@@ -150,6 +150,7 @@ models:
   - transit_pass_subsidy
   - transit_pass_ownership
   - vehicle_type_choice
+  - adjust_auto_operating_cost
   - transponder_ownership
   - free_parking
   - telecommute_frequency

--- a/src/asim/configs/resident/settings_mp.yaml
+++ b/src/asim/configs/resident/settings_mp.yaml
@@ -38,6 +38,7 @@ models:
   - transit_pass_subsidy
   - transit_pass_ownership
   - vehicle_type_choice
+  - adjust_auto_operating_cost
   - transponder_ownership
   - free_parking
   - telecommute_frequency

--- a/src/asim/extensions/__init__.py
+++ b/src/asim/extensions/__init__.py
@@ -5,3 +5,4 @@ from . import transponder_ownership
 from . import airport_returns
 # from . import write_to_datalake
 from . import update_tables
+from . import adjust_auto_operating_cost

--- a/src/asim/extensions/adjust_auto_operating_cost.py
+++ b/src/asim/extensions/adjust_auto_operating_cost.py
@@ -1,0 +1,30 @@
+import logging
+
+import numpy as np
+import pandas as pd
+
+from activitysim.core import(
+    config,
+    inject,
+    pipeline,
+)
+
+logger = logging.getLogger(__name__)
+
+@inject.step()
+def adjust_auto_operating_cost(vehicles):
+    """Adjusts the `auto_operating_cost` field in the vehicles table
+    so that the average is a desired value set as costPerMile in the
+    settings
+
+    Parameters
+    ----------
+    vehicles : orca.DataFrameWrapper
+    """
+    target_auto_operating_cost = config.get_global_constants()["costPerMile"]
+    vehicles = vehicles.to_frame()
+
+    adjustment_factor = target_auto_operating_cost / vehicles["auto_operating_cost"].mean()
+    vehicles["auto_operating_cost"] *= adjustment_factor
+
+    pipeline.replace_table("vehicles", vehicles)

--- a/src/asim/extensions/adjust_auto_operating_cost.py
+++ b/src/asim/extensions/adjust_auto_operating_cost.py
@@ -25,6 +25,7 @@ def adjust_auto_operating_cost(vehicles):
     vehicles = vehicles.to_frame()
 
     adjustment_factor = target_auto_operating_cost / vehicles["auto_operating_cost"].mean()
+    logger.info("Adjusting auto operating costs in vehicles table by a factor of {}".format(adjustment_factor))
     vehicles["auto_operating_cost"] *= adjustment_factor
 
     pipeline.replace_table("vehicles", vehicles)


### PR DESCRIPTION
Extra step to adjust the auto operating costs in the vehicles table to average out to costPerMile in constants.yaml (derived from aoc.fuel and aoc.maintenance in sandag_abm.properties)