### PR TITLE
Recode body and fuel type as integers in vehicle type choice model

### DIFF
--- a/src/asim/configs/resident/vehicle_type_choice.yaml
+++ b/src/asim/configs/resident/vehicle_type_choice.yaml
@@ -91,6 +91,38 @@ preprocessor:
     - persons
     - households
 
+alts_preprocessor:
+  SPEC: vehicle_type_choice_annotate_alts_preprocessor
+  DF: alts_wide
+
+COLS_TO_INCLUDE_IN_CHOOSER_TABLE:
+  - avg_hh_dist_to_work
+  - income
+  - hh_per_mi
+  - auto_ownership
+  - hh_veh_gt_drivers
+  - total_hh_dist_to_work_cap
+  - num_children
+  - num_hh_veh_owned
+  - num_hh_Van
+  - num_hh_SUV
+  - num_hh_Pickup
+  - num_hh_Motorcycle
+  - num_hh_Hybrid
+  - num_hh_BEV
+  - num_hh_PEV
+  - num_hh_EV
+  - home_is_rural
+
+COLS_TO_INCLUDE_IN_ALTERNATIVES_TABLE:
+  - age
+  - fuel_type_num_coded
+  - body_type_num_coded
+  - Range
+  - MPG
+  - NumMakes
+  - NumModels
+
 # annotate_persons:
 #   SPEC: annotate_persons_vehicle_type
 #   DF: persons

--- a/src/asim/configs/resident/vehicle_type_choice.yaml
+++ b/src/asim/configs/resident/vehicle_type_choice.yaml
@@ -95,25 +95,6 @@ alts_preprocessor:
   SPEC: vehicle_type_choice_annotate_alts_preprocessor
   DF: alts_wide
 
-COLS_TO_INCLUDE_IN_CHOOSER_TABLE:
-  - avg_hh_dist_to_work
-  - income
-  - hh_per_mi
-  - auto_ownership
-  - hh_veh_gt_drivers
-  - total_hh_dist_to_work_cap
-  - num_children
-  - num_hh_veh_owned
-  - num_hh_Van
-  - num_hh_SUV
-  - num_hh_Pickup
-  - num_hh_Motorcycle
-  - num_hh_Hybrid
-  - num_hh_BEV
-  - num_hh_PEV
-  - num_hh_EV
-  - home_is_rural
-
 COLS_TO_INCLUDE_IN_ALTERNATIVES_TABLE:
   - age
   - fuel_type_num_coded

--- a/src/asim/configs/resident/vehicle_type_choice.yaml
+++ b/src/asim/configs/resident/vehicle_type_choice.yaml
@@ -120,8 +120,10 @@ COLS_TO_INCLUDE_IN_ALTERNATIVES_TABLE:
   - body_type_num_coded
   - Range
   - MPG
-  - NumMakes
-  - NumModels
+  - is_av
+  - logged_models
+  - logged_makes
+  - logged_chargers_per_capita
 
 # annotate_persons:
 #   SPEC: annotate_persons_vehicle_type

--- a/src/asim/configs/resident/vehicle_type_choice.yaml
+++ b/src/asim/configs/resident/vehicle_type_choice.yaml
@@ -124,6 +124,7 @@ COLS_TO_INCLUDE_IN_ALTERNATIVES_TABLE:
   - logged_models
   - logged_makes
   - logged_chargers_per_capita
+  - SAN
 
 # annotate_persons:
 #   SPEC: annotate_persons_vehicle_type

--- a/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
@@ -1,0 +1,7 @@
+Description,Target,Expression
+mapping fuel type to integers,fuel_type_num_coded,"df.fuel_type.map({'BEV': 1, 'Diesel': 2, 'Gas': 3, 'Hybrid': 4, 'PEV': 5}).astype(int)"
+mapping body type to integers,body_type_num_coded,"df.body_type.map({'Car': 1, 'Motorcycle': 2, 'Pickup': 3, 'SUV': 4, 'Van': 5}).astype(int)"
+# moving log terms to preprocessor to avoid expensive log calculations,,
+log number of models available,logged_models,"np.log(1 + df.NumModels)"
+log number of makes available,logged_makes,"np.log(1 + df.NumMakes)"
+logged chargers per capita,logged_chargers_per_capita,"np.log(1 + CHARGERS_PER_CAP)"

--- a/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
@@ -1,6 +1,7 @@
 Description,Target,Expression
 mapping fuel type to integers,fuel_type_num_coded,"df.fuel_type.map({'BEV': 1, 'Diesel': 2, 'Gas': 3, 'Hybrid': 4, 'PEV': 5}).astype(int)"
-mapping body type to integers,body_type_num_coded,"df.body_type.map({'Car': 1, 'Motorcycle': 2, 'Pickup': 3, 'SUV': 4, 'Van': 5}).astype(int)"
+mapping body type to integers,body_type_num_coded,"df.body_type.map({'Car': 1, 'Motorcycle': 2, 'Pickup': 3, 'SUV': 4, 'Van': 5, 'Car-AV': 1, 'Motorcycle-AV': 2, 'Pickup-AV': 3, 'SUV-AV': 4, 'Van-AV': 5}).astype(int)"
+flag indicating if vehicle is AV,is_av,"df.body_type.str.contains('AV')"
 # moving log terms to preprocessor to avoid expensive log calculations,,
 log number of models available,logged_models,"np.log(1 + df.NumModels)"
 log number of makes available,logged_makes,"np.log(1 + df.NumMakes)"

--- a/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_annotate_alts_preprocessor.csv
@@ -2,6 +2,7 @@ Description,Target,Expression
 mapping fuel type to integers,fuel_type_num_coded,"df.fuel_type.map({'BEV': 1, 'Diesel': 2, 'Gas': 3, 'Hybrid': 4, 'PEV': 5}).astype(int)"
 mapping body type to integers,body_type_num_coded,"df.body_type.map({'Car': 1, 'Motorcycle': 2, 'Pickup': 3, 'SUV': 4, 'Van': 5, 'Car-AV': 1, 'Motorcycle-AV': 2, 'Pickup-AV': 3, 'SUV-AV': 4, 'Van-AV': 5}).astype(int)"
 flag indicating if vehicle is AV,is_av,"df.body_type.str.contains('AV')"
+flag for SAN-specific contants,SAN,True
 # moving log terms to preprocessor to avoid expensive log calculations,,
 log number of models available,logged_models,"np.log(1 + df.NumModels)"
 log number of makes available,logged_makes,"np.log(1 + df.NumMakes)"

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -46,10 +46,10 @@ util_den6_mc,4000-9999 HH / sq mi Motorcycle,"((household_density < 10000) & (ho
 util_den7_mc,10000-24999 HH / sq mi Motorcycle,"((household_density < 25000) & (household_density >= 10000)) & (body_type_num_coded==2)",coef_den7_mc
 util_den8_mc,25000+ HH / sq mi Motorcycle,"(household_density >= 25000) & (body_type_num_coded==2)",coef_den8_mc
 util_den3_hyb,500-999 HH / sq mi Hybrid,"((household_density < 1000) & (household_density >= 500)) & (fuel_type_num_coded==4)",coef_den3_hyb
-util_den4_hyb,1000-1999 HH / sq mi Hybrid,"((household_density < 2000) & (household_density >= 1000)) & (fuel_type_num_coded==4')",coef_den4_hyb
-util_den5_hyb,2000-3999 HH / sq mi Hybrid,"((household_density < 4000) & (household_density >= 2000)) & (fuel_type_num_coded==4')",coef_den5_hyb
-util_den6_hyb,4000-9999 HH / sq mi Hybrid,"((household_density < 10000) & (household_density >= 4000)) & (fuel_type_num_coded==4')",coef_den6_hyb
-util_den7_hyb,10000-24999 HH / sq mi Hybrid,"((household_density < 25000) & (household_density >= 10000)) & (fuel_type_num_coded==4')",coef_den7_hyb
+util_den4_hyb,1000-1999 HH / sq mi Hybrid,"((household_density < 2000) & (household_density >= 1000)) & (fuel_type_num_coded==4)",coef_den4_hyb
+util_den5_hyb,2000-3999 HH / sq mi Hybrid,"((household_density < 4000) & (household_density >= 2000)) & (fuel_type_num_coded==4)",coef_den5_hyb
+util_den6_hyb,4000-9999 HH / sq mi Hybrid,"((household_density < 10000) & (household_density >= 4000)) & (fuel_type_num_coded==4)",coef_den6_hyb
+util_den7_hyb,10000-24999 HH / sq mi Hybrid,"((household_density < 25000) & (household_density >= 10000)) & (fuel_type_num_coded==4)",coef_den7_hyb
 util_den8_hyb,25000+ HH / sq mi Hybrid,"(household_density >= 25000) & (fuel_type_num_coded==4)",coef_den8_hyb
 util_den34_ev,500-1999 HH / sq mi Electric,"((household_density < 2000) & (household_density >= 500)) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den34_ev
 util_den5_ev,2000-3999 HH / sq mi Electric,"((household_density < 4000) & (household_density >= 2000)) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den5_ev

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -21,92 +21,92 @@ util_i100_age,Vehicle Age Segmented by Income,"((income < 150000) & (income >= 1
 util_i150p_age,Vehicle Age Segmented by Income,"((income < 150000) & (income >= 100000)) * age",coef_i150p_age
 util_imiss_age,Vehicle Age Missing Income,"((income < 0) | income.isna()) * age",coef_imiss_age
 #,household density variables,,
-util_den3_van,500-999 HH / sq mi Van,"((household_density < 1000) & (household_density >= 500)) & (body_type.str.contains('Van'))",coef_den3_van
-util_den4_van,1000-1999 HH / sq mi Van,"((household_density < 2000) & (household_density >= 1000)) & (body_type.str.contains('Van'))",coef_den4_van
-util_den5_van,2000-3999 HH / sq mi Van,"((household_density < 4000) & (household_density >= 2000)) & (body_type.str.contains('Van'))",coef_den5_van
-util_den6_van,4000-9999 HH / sq mi Van,"((household_density < 10000) & (household_density >= 4000)) & (body_type.str.contains('Van'))",coef_den6_van
-util_den7_van,10000-24999 HH / sq mi Van,"((household_density < 25000) & (household_density >= 10000)) & (body_type.str.contains('Van'))",coef_den7_van
-util_den8_van,25000+ HH / sq mi Van,"(household_density >= 25000) & (body_type.str.contains('Van'))",coef_den8_van
-util_den3_suv,500-999 HH / sq mi SUV,"((household_density < 1000) & (household_density >= 500)) & (body_type.str.contains('SUV'))",coef_den3_suv
-util_den4_suv,1000-1999 HH / sq mi SUV,"((household_density < 2000) & (household_density >= 1000)) & (body_type.str.contains('SUV'))",coef_den4_suv
-util_den5_suv,2000-3999 HH / sq mi SUV,"((household_density < 4000) & (household_density >= 2000)) & (body_type.str.contains('SUV'))",coef_den5_suv
-util_den6_suv,4000-9999 HH / sq mi SUV,"((household_density < 10000) & (household_density >= 4000)) & (body_type.str.contains('SUV'))",coef_den6_suv
-util_den7_suv,10000-24999 HH / sq mi SUV,"((household_density < 25000) & (household_density >= 10000)) & (body_type.str.contains('SUV'))",coef_den7_suv
-util_den8_suv,25000+ HH / sq mi SUV,"(household_density >= 25000) & (body_type.str.contains('SUV'))",coef_den8_suv
-util_den3_pu,500-999 HH / sq mi Pickup,"((household_density < 1000) & (household_density >= 500)) & (body_type.str.contains('Pickup'))",coef_den3_pu
-util_den4_pu,1000-1999 HH / sq mi Pickup,"((household_density < 2000) & (household_density >= 1000)) & (body_type.str.contains('Pickup'))",coef_den4_pu
-util_den5_pu,2000-3999 HH / sq mi Pickup,"((household_density < 4000) & (household_density >= 2000)) & (body_type.str.contains('Pickup'))",coef_den5_pu
-util_den6_pu,4000-9999 HH / sq mi Pickup,"((household_density < 10000) & (household_density >= 4000)) & (body_type.str.contains('Pickup'))",coef_den6_pu
-util_den7_pu,10000-24999 HH / sq mi Pickup,"((household_density < 25000) & (household_density >= 10000)) & (body_type.str.contains('Pickup'))",coef_den7_pu
-util_den8_mc,25000+ HH / sq mi Pickup,"(household_density >= 25000) & (body_type.str.contains('Pickup'))",coef_den8_pu
-util_den3_mc,500-999 HH / sq mi Motorcycle,"((household_density < 1000) & (household_density >= 500)) & (body_type.str.contains('Motorcycle'))",coef_den3_mc
-util_den4_mc,1000-1999 HH / sq mi Motorcycle,"((household_density < 2000) & (household_density >= 1000)) & (body_type.str.contains('Motorcycle'))",coef_den4_mc
-util_den5_mc,2000-3999 HH / sq mi Motorcycle,"((household_density < 4000) & (household_density >= 2000)) & (body_type.str.contains('Motorcycle'))",coef_den5_mc
-util_den6_mc,4000-9999 HH / sq mi Motorcycle,"((household_density < 10000) & (household_density >= 4000)) & (body_type.str.contains('Motorcycle'))",coef_den6_mc
-util_den7_mc,10000-24999 HH / sq mi Motorcycle,"((household_density < 25000) & (household_density >= 10000)) & (body_type.str.contains('Motorcycle'))",coef_den7_mc
-util_den8_mc,25000+ HH / sq mi Motorcycle,"(household_density >= 25000) & (body_type.str.contains('Motorcycle'))",coef_den8_mc
-util_den3_hyb,500-999 HH / sq mi Hybrid,"((household_density < 1000) & (household_density >= 500)) & (fuel_type == 'Hybrid')",coef_den3_hyb
-util_den4_hyb,1000-1999 HH / sq mi Hybrid,"((household_density < 2000) & (household_density >= 1000)) & (fuel_type == 'Hybrid')",coef_den4_hyb
-util_den5_hyb,2000-3999 HH / sq mi Hybrid,"((household_density < 4000) & (household_density >= 2000)) & (fuel_type == 'Hybrid')",coef_den5_hyb
-util_den6_hyb,4000-9999 HH / sq mi Hybrid,"((household_density < 10000) & (household_density >= 4000)) & (fuel_type == 'Hybrid')",coef_den6_hyb
-util_den7_hyb,10000-24999 HH / sq mi Hybrid,"((household_density < 25000) & (household_density >= 10000)) & (fuel_type == 'Hybrid')",coef_den7_hyb
-util_den8_hyb,25000+ HH / sq mi Hybrid,"(household_density >= 25000) & (fuel_type == 'Hybrid')",coef_den8_hyb
-util_den34_ev,500-1999 HH / sq mi Electric,"((household_density < 2000) & (household_density >= 500)) & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_den34_ev
-util_den5_ev,2000-3999 HH / sq mi Electric,"((household_density < 4000) & (household_density >= 2000)) & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_den5_ev
-util_den6_ev,4000-9999 HH / sq mi Electric,"((household_density < 10000) & (household_density >= 4000)) & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_den6_ev
-util_den78_ev,10000+ HH / sq mi Electric,"(household_density >= 10000) & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_den78_ev
+util_den3_van,500-999 HH / sq mi Van,"((household_density < 1000) & (household_density >= 500)) & (body_type_num_coded==5)",coef_den3_van
+util_den4_van,1000-1999 HH / sq mi Van,"((household_density < 2000) & (household_density >= 1000)) & (body_type_num_coded==5)",coef_den4_van
+util_den5_van,2000-3999 HH / sq mi Van,"((household_density < 4000) & (household_density >= 2000)) & (body_type_num_coded==5)",coef_den5_van
+util_den6_van,4000-9999 HH / sq mi Van,"((household_density < 10000) & (household_density >= 4000)) & (body_type_num_coded==5)",coef_den6_van
+util_den7_van,10000-24999 HH / sq mi Van,"((household_density < 25000) & (household_density >= 10000)) & (body_type_num_coded==5)",coef_den7_van
+util_den8_van,25000+ HH / sq mi Van,"(household_density >= 25000) & (body_type_num_coded==5)",coef_den8_van
+util_den3_suv,500-999 HH / sq mi SUV,"((household_density < 1000) & (household_density >= 500)) & (body_type_num_coded==4)",coef_den3_suv
+util_den4_suv,1000-1999 HH / sq mi SUV,"((household_density < 2000) & (household_density >= 1000)) & (body_type_num_coded==4)",coef_den4_suv
+util_den5_suv,2000-3999 HH / sq mi SUV,"((household_density < 4000) & (household_density >= 2000)) & (body_type_num_coded==4)",coef_den5_suv
+util_den6_suv,4000-9999 HH / sq mi SUV,"((household_density < 10000) & (household_density >= 4000)) & (body_type_num_coded==4)",coef_den6_suv
+util_den7_suv,10000-24999 HH / sq mi SUV,"((household_density < 25000) & (household_density >= 10000)) & (body_type_num_coded==4)",coef_den7_suv
+util_den8_suv,25000+ HH / sq mi SUV,"(household_density >= 25000) & (body_type_num_coded==4)",coef_den8_suv
+util_den3_pu,500-999 HH / sq mi Pickup,"((household_density < 1000) & (household_density >= 500)) & (body_type_num_coded==3)",coef_den3_pu
+util_den4_pu,1000-1999 HH / sq mi Pickup,"((household_density < 2000) & (household_density >= 1000)) & (body_type_num_coded==3)",coef_den4_pu
+util_den5_pu,2000-3999 HH / sq mi Pickup,"((household_density < 4000) & (household_density >= 2000)) & (body_type_num_coded==3)",coef_den5_pu
+util_den6_pu,4000-9999 HH / sq mi Pickup,"((household_density < 10000) & (household_density >= 4000)) & (body_type_num_coded==3)",coef_den6_pu
+util_den7_pu,10000-24999 HH / sq mi Pickup,"((household_density < 25000) & (household_density >= 10000)) & (body_type_num_coded==3)",coef_den7_pu
+util_den8_mc,25000+ HH / sq mi Pickup,"(household_density >= 25000) & (body_type_num_coded==3)",coef_den8_pu
+util_den3_mc,500-999 HH / sq mi Motorcycle,"((household_density < 1000) & (household_density >= 500)) & (body_type_num_coded==2)",coef_den3_mc
+util_den4_mc,1000-1999 HH / sq mi Motorcycle,"((household_density < 2000) & (household_density >= 1000)) & (body_type_num_coded==2)",coef_den4_mc
+util_den5_mc,2000-3999 HH / sq mi Motorcycle,"((household_density < 4000) & (household_density >= 2000)) & (body_type_num_coded==2)",coef_den5_mc
+util_den6_mc,4000-9999 HH / sq mi Motorcycle,"((household_density < 10000) & (household_density >= 4000)) & (body_type_num_coded==2)",coef_den6_mc
+util_den7_mc,10000-24999 HH / sq mi Motorcycle,"((household_density < 25000) & (household_density >= 10000)) & (body_type_num_coded==2)",coef_den7_mc
+util_den8_mc,25000+ HH / sq mi Motorcycle,"(household_density >= 25000) & (body_type_num_coded==2)",coef_den8_mc
+util_den3_hyb,500-999 HH / sq mi Hybrid,"((household_density < 1000) & (household_density >= 500)) & (fuel_type_num_coded==4)",coef_den3_hyb
+util_den4_hyb,1000-1999 HH / sq mi Hybrid,"((household_density < 2000) & (household_density >= 1000)) & (fuel_type_num_coded==4')",coef_den4_hyb
+util_den5_hyb,2000-3999 HH / sq mi Hybrid,"((household_density < 4000) & (household_density >= 2000)) & (fuel_type_num_coded==4')",coef_den5_hyb
+util_den6_hyb,4000-9999 HH / sq mi Hybrid,"((household_density < 10000) & (household_density >= 4000)) & (fuel_type_num_coded==4')",coef_den6_hyb
+util_den7_hyb,10000-24999 HH / sq mi Hybrid,"((household_density < 25000) & (household_density >= 10000)) & (fuel_type_num_coded==4')",coef_den7_hyb
+util_den8_hyb,25000+ HH / sq mi Hybrid,"(household_density >= 25000) & (fuel_type_num_coded==4)",coef_den8_hyb
+util_den34_ev,500-1999 HH / sq mi Electric,"((household_density < 2000) & (household_density >= 500)) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den34_ev
+util_den5_ev,2000-3999 HH / sq mi Electric,"((household_density < 4000) & (household_density >= 2000)) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den5_ev
+util_den6_ev,4000-9999 HH / sq mi Electric,"((household_density < 10000) & (household_density >= 4000)) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den6_ev
+util_den78_ev,10000+ HH / sq mi Electric,"(household_density >= 10000) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_den78_ev
 #,household drivers,,
 util_oneveh_age,Household owns only one vehicle * vehicle age,"(auto_ownership == 1) * age",coef_oneveh_age
-util_vhgtdr_van,Household vehicles gt drivers for Van,hh_veh_gt_drivers * (body_type.str.contains('Van')),coef_vhgtdr_van
-util_vhgtdr_suv,Household vehicles gt drivers for SUV,hh_veh_gt_drivers * (body_type.str.contains('SUV')),coef_vhgtdr_suv
-util_vhgtdr_pu,Household vehicles gt drivers for Pickup,hh_veh_gt_drivers * (body_type.str.contains('Pickup')),coef_vhgtdr_pu
-util_vhgtdr_mc,Household vehicles gt drivers for Motorcycle,hh_veh_gt_drivers * (body_type.str.contains('Motorcycle')),coef_vhgtdr_mc
-util_vhgtdr_hy,Household vehicles gt drivers for Hybrid,hh_veh_gt_drivers * (fuel_type == 'Hybrid'),coef_vhgtdr_hy
-util_vhgtdr_ev,Household vehicles gt drivers for EVs,hh_veh_gt_drivers * ((fuel_type == 'PEV') | (fuel_type == 'BEV')),coef_vhgtdr_ev
+util_vhgtdr_van,Household vehicles gt drivers for Van,hh_veh_gt_drivers * (body_type_num_coded==5),coef_vhgtdr_van
+util_vhgtdr_suv,Household vehicles gt drivers for SUV,hh_veh_gt_drivers * (body_type_num_coded==4),coef_vhgtdr_suv
+util_vhgtdr_pu,Household vehicles gt drivers for Pickup,hh_veh_gt_drivers * (body_type_num_coded==3),coef_vhgtdr_pu
+util_vhgtdr_mc,Household vehicles gt drivers for Motorcycle,hh_veh_gt_drivers * (body_type_num_coded==2),coef_vhgtdr_mc
+util_vhgtdr_hy,Household vehicles gt drivers for Hybrid,hh_veh_gt_drivers * (fuel_type_num_coded==4),coef_vhgtdr_hy
+util_vhgtdr_ev,Household vehicles gt drivers for EVs,hh_veh_gt_drivers * ((fuel_type_num_coded==5) | (fuel_type_num_coded==1)),coef_vhgtdr_ev
 util_vhgtdr_age,Household vehicles gt drivers for age,hh_veh_gt_drivers * age,coef_vhgtdr_age
 #,interacting with number of children,,
-util_nchld_van,Number of children max 3 * Van,num_children.clip(upper=3) * (body_type.str.contains('Van')),coef_nchld_van
-util_nchld_suv,Number of children max 3 * SUV,num_children.clip(upper=3) * (body_type.str.contains('SUV')),coef_nchld_suv
-util_nchld_pu,Number of children max 3 * Pickup,num_children.clip(upper=3) * (body_type.str.contains('Pickup')),coef_nchld_pu
-util_nchld_mc,Number of children max 3 * Motorcycle,num_children.clip(upper=3) * (body_type.str.contains('Motorcycle')),coef_nchld_mc
-util_nchld_hy,Number of children max 3 * Hybrid,num_children.clip(upper=3) * (fuel_type == 'Hybrid'),coef_nchld_hy
-util_nchld_ev,Number of children max 3 * EVs,num_children.clip(upper=3) * ((fuel_type == 'PEV') | (fuel_type == 'BEV')),coef_nchld_ev
+util_nchld_van,Number of children max 3 * Van,num_children.clip(upper=3) * (body_type_num_coded==5),coef_nchld_van
+util_nchld_suv,Number of children max 3 * SUV,num_children.clip(upper=3) * (body_type_num_coded==4),coef_nchld_suv
+util_nchld_pu,Number of children max 3 * Pickup,num_children.clip(upper=3) * (body_type_num_coded==3),coef_nchld_pu
+util_nchld_mc,Number of children max 3 * Motorcycle,num_children.clip(upper=3) * (body_type_num_coded==2),coef_nchld_mc
+util_nchld_hy,Number of children max 3 * Hybrid,num_children.clip(upper=3) * (fuel_type_num_coded==4),coef_nchld_hy
+util_nchld_ev,Number of children max 3 * EVs,num_children.clip(upper=3) * ((fuel_type_num_coded==5) | (fuel_type_num_coded==1)),coef_nchld_ev
 util_nchld_age,Number of children max 3 * age,num_children.clip(upper=3) * age,coef_nchld_age
 util_dstwkt_age,Total distance to work * age,total_hh_dist_to_work_cap * age,coef_dstwkt_age
 #,household already owning vehicles,,
-util_van_van,Household already owns a Van -- Van,"(num_hh_Van > 0) & (body_type.str.contains('Van'))",coef_van_van
-util_van_suv,Household already owns a Van -- SUV,"(num_hh_Van > 0) & (body_type.str.contains('SUV'))",coef_van_suv
-util_van_pu,Household already owns a Van -- Pickup,"(num_hh_Van > 0) & (body_type.str.contains('Pickup'))",coef_van_pu
-util_van_mc,Household already owns a Van -- Motorcycle,"(num_hh_Van > 0) & (body_type.str.contains('Motorcycle'))",coef_van_mc
-util_van_suv,Household already owns an SUV -- Van (symmetrical with above),"(num_hh_SUV > 0) & (body_type.str.contains('Van'))",coef_van_suv
-util_suv_suv,Household already owns an SUV -- SUV,"(num_hh_SUV > 0) & (body_type.str.contains('SUV'))",coef_suv_suv
-util_suv_pu,Household already owns an SUV -- Pickup,"(num_hh_SUV > 0) & (body_type.str.contains('Pickup'))",coef_suv_pu
-util_suv_mc,Household already owns an SUV -- Motorcycle,"(num_hh_SUV > 0) & (body_type.str.contains('Motorcycle'))",coef_suv_mc
-util_van_pu,Household already owns a Pickup -- Van (symmetrical with above),"(num_hh_Pickup > 0) & (body_type.str.contains('Van'))",coef_van_pu
-util_suv_pu,Household already owns a Pickup -- SUV (symmetrical with above),"(num_hh_Pickup > 0) & (body_type.str.contains('SUV'))",coef_suv_pu
-util_pu_pu,Household already owns a Pickup -- Pickup,"(num_hh_Pickup > 0) & (body_type.str.contains('Pickup'))",coef_pu_pu
-util_pu_mc,Household already owns a Pickup -- Motorcycle,"(num_hh_Pickup > 0) & (body_type.str.contains('Motorcycle'))",coef_pu_mc
-util_van_mc,Household already owns a Motorcycle -- Van (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type.str.contains('Van'))",coef_van_mc
-util_suv_mc,Household already owns a Motorcycle -- SUV (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type.str.contains('SUV'))",coef_suv_mc
-util_pu_mc,Household already owns a Motorcycle -- Pickup (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type.str.contains('Pickup'))",coef_pu_mc
-util_mc_mc,Household already owns a Motorcycle -- Motorcycle,"(num_hh_Motorcycle > 0) & (body_type.str.contains('Motorcycle'))",coef_mc_mc
-util_hyb_hyb,Houeshold already owns a Hybrid -- Hybrid,"(num_hh_Hybrid > 0) & (fuel_type == 'Hybrid')",coef_hyb_hyb
-util_hyb_ev,Houeshold already owns a Hybrid -- EV,"(num_hh_Hybrid > 0) & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_hyb_ev
-util_hyb_ev,Houeshold already owns an EV -- Hybrid (symmetrical with above),"(num_hh_EV> 0) & (fuel_type == 'Hybrid')",coef_hyb_ev
-util_only_van,Household only owns Vans,"(num_hh_Van > 0) & (num_hh_Van == num_hh_veh_owned) & (body_type.str.contains('Van'))",coef_only_van
-util_only_suv,Household only owns SUVs,"(num_hh_SUV > 0) & (num_hh_SUV == num_hh_veh_owned) & (body_type.str.contains('SUV'))",coef_only_suv
-util_only_pu,Household only owns Pickups,"(num_hh_Pickup > 0) & (num_hh_Pickup == num_hh_veh_owned) & (body_type.str.contains('Pickup'))",coef_only_pu
-util_only_mc,Household only owns Motorcycles,"(num_hh_Motorcycle > 0) & (num_hh_Motorcycle == num_hh_veh_owned) & (body_type.str.contains('Motorcycle'))",coef_only_mc
-util_only_bev,Household only owns BEVs,"(num_hh_BEV > 0) & (num_hh_BEV == num_hh_veh_owned) & (fuel_type == 'BEV')",coef_only_bev
+util_van_van,Household already owns a Van -- Van,"(num_hh_Van > 0) & (body_type_num_coded==5)",coef_van_van
+util_van_suv,Household already owns a Van -- SUV,"(num_hh_Van > 0) & (body_type_num_coded==4)",coef_van_suv
+util_van_pu,Household already owns a Van -- Pickup,"(num_hh_Van > 0) & (body_type_num_coded==3)",coef_van_pu
+util_van_mc,Household already owns a Van -- Motorcycle,"(num_hh_Van > 0) & (body_type_num_coded==2)",coef_van_mc
+util_van_suv,Household already owns an SUV -- Van (symmetrical with above),"(num_hh_SUV > 0) & (body_type_num_coded==5)",coef_van_suv
+util_suv_suv,Household already owns an SUV -- SUV,"(num_hh_SUV > 0) & (body_type_num_coded==4)",coef_suv_suv
+util_suv_pu,Household already owns an SUV -- Pickup,"(num_hh_SUV > 0) & (body_type_num_coded==3)",coef_suv_pu
+util_suv_mc,Household already owns an SUV -- Motorcycle,"(num_hh_SUV > 0) & (body_type_num_coded==2)",coef_suv_mc
+util_van_pu,Household already owns a Pickup -- Van (symmetrical with above),"(num_hh_Pickup > 0) & (body_type_num_coded==5)",coef_van_pu
+util_suv_pu,Household already owns a Pickup -- SUV (symmetrical with above),"(num_hh_Pickup > 0) & (body_type_num_coded==4)",coef_suv_pu
+util_pu_pu,Household already owns a Pickup -- Pickup,"(num_hh_Pickup > 0) & (body_type_num_coded==3)",coef_pu_pu
+util_pu_mc,Household already owns a Pickup -- Motorcycle,"(num_hh_Pickup > 0) & (body_type_num_coded==2)",coef_pu_mc
+util_van_mc,Household already owns a Motorcycle -- Van (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type_num_coded==5)",coef_van_mc
+util_suv_mc,Household already owns a Motorcycle -- SUV (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type_num_coded==4)",coef_suv_mc
+util_pu_mc,Household already owns a Motorcycle -- Pickup (symmetrical with above),"(num_hh_Motorcycle > 0) & (body_type_num_coded==3)",coef_pu_mc
+util_mc_mc,Household already owns a Motorcycle -- Motorcycle,"(num_hh_Motorcycle > 0) & (body_type_num_coded==2)",coef_mc_mc
+util_hyb_hyb,Houeshold already owns a Hybrid -- Hybrid,"(num_hh_Hybrid > 0) & (fuel_type_num_coded==4)",coef_hyb_hyb
+util_hyb_ev,Houeshold already owns a Hybrid -- EV,"(num_hh_Hybrid > 0) & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_hyb_ev
+util_hyb_ev,Houeshold already owns an EV -- Hybrid (symmetrical with above),"(num_hh_EV> 0) & (fuel_type_num_coded==4)",coef_hyb_ev
+util_only_van,Household only owns Vans,"(num_hh_Van > 0) & (num_hh_Van == num_hh_veh_owned) & (body_type_num_coded==5)",coef_only_van
+util_only_suv,Household only owns SUVs,"(num_hh_SUV > 0) & (num_hh_SUV == num_hh_veh_owned) & (body_type_num_coded==4)",coef_only_suv
+util_only_pu,Household only owns Pickups,"(num_hh_Pickup > 0) & (num_hh_Pickup == num_hh_veh_owned) & (body_type_num_coded==3)",coef_only_pu
+util_only_mc,Household only owns Motorcycles,"(num_hh_Motorcycle > 0) & (num_hh_Motorcycle == num_hh_veh_owned) & (body_type_num_coded==2)",coef_only_mc
+util_only_bev,Household only owns BEVs,"(num_hh_BEV > 0) & (num_hh_BEV == num_hh_veh_owned) & (fuel_type_num_coded==1)",coef_only_bev
 #,constants,,
-util_van,Van ASC,(body_type.str.contains('Van')),coef_van
-util_suv,SUV ASC,(body_type.str.contains('SUV')),coef_suv
-util_pu,Pickup ASC,(body_type.str.contains('Pickup')),coef_pu
-util_mc,Motorcycle ASC,(body_type.str.contains('Motorcycle')),coef_mc
-util_dsl,Diesel ASC,(fuel_type == 'Diesel'),coef_dsl
-util_hyb,Hybrid ASC,(fuel_type == 'Hybrid'),coef_hyb
-util_pev,PEV ASC,(fuel_type == 'PEV'),coef_pev
-util_bev,BEV ASC,(fuel_type == 'BEV'),coef_bev
+util_van,Van ASC,(body_type_num_coded==5),coef_van
+util_suv,SUV ASC,(body_type_num_coded==4),coef_suv
+util_pu,Pickup ASC,(body_type_num_coded==3),coef_pu
+util_mc,Motorcycle ASC,(body_type_num_coded==2),coef_mc
+util_dsl,Diesel ASC,(fuel_type_num_coded==2),coef_dsl
+util_hyb,Hybrid ASC,(fuel_type_num_coded==4),coef_hyb
+util_pev,PEV ASC,(fuel_type_num_coded==5),coef_pev
+util_bev,BEV ASC,(fuel_type_num_coded==1),coef_bev
 util_age2,Age 2 ASC,(age==2),coef_age2
 util_age3,Age 3 ASC,(age==3),coef_age3
 util_age4,Age 4 ASC,(age==4),coef_age4
@@ -127,82 +127,26 @@ util_age18,Age 18 ASC,(age==18),coef_age18
 util_age19,Age 19 ASC,(age==19),coef_age19
 util_age20,Age 20 ASC,(age==20),coef_age20
 #,rural household coefficients,,
-util_rural_van,Household is in Rural Area - Van,"home_is_rural & (body_type.str.contains('Van'))",coef_rural_van
-util_rural_suv,Household is in Rural Area - SUV,"home_is_rural & (body_type.str.contains('SUV'))",coef_rural_suv
-util_rural_pu,Household is in Rural Area - Pickup,"home_is_rural & (body_type.str.contains('Pickup'))",coef_rural_pu
-util_rural_mc,Household is in Rural Area - Motorcycle,"home_is_rural & (body_type.str.contains('Motorcycle'))",coef_rural_mc
-util_rural_hyb,Household is in Rural Area - Hybrid,"home_is_rural & (fuel_type == 'Hybrid')",coef_rural_hyb
-util_rural_ev,Household is in Rural Area - Electric,"home_is_rural & ((fuel_type == 'PEV') | (fuel_type == 'BEV'))",coef_rural_ev
+util_rural_van,Household is in Rural Area - Van,"home_is_rural & (body_type_num_coded==5)",coef_rural_van
+util_rural_suv,Household is in Rural Area - SUV,"home_is_rural & (body_type_num_coded==4)",coef_rural_suv
+util_rural_pu,Household is in Rural Area - Pickup,"home_is_rural & (body_type_num_coded==3)",coef_rural_pu
+util_rural_mc,Household is in Rural Area - Motorcycle,"home_is_rural & (body_type_num_coded==2)",coef_rural_mc
+util_rural_hyb,Household is in Rural Area - Hybrid,"home_is_rural & (fuel_type_num_coded==4)",coef_rural_hyb
+util_rural_ev,Household is in Rural Area - Electric,"home_is_rural & ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_rural_ev
 util_rural_age,Household is in Rural Area - Age,"home_is_rural * age",coef_rural_age
 #,MSA population coefficients,,
-util_smsa_van,MSA population less than 1 million - Van,"@(MSA_POP < 1000000) & (df.body_type.str.contains('Van'))",coef_smsa_van
-util_smsa_suv,MSA population less than 1 million - SUV,"@(MSA_POP < 1000000) & (df.body_type.str.contains('SUV'))",coef_smsa_suv
-util_smsa_pu,MSA population less than 1 million - Pickup,"@(MSA_POP < 1000000) & (df.body_type.str.contains('Pickup'))",coef_smsa_pu
-util_smsa_mc,MSA population less than 1 million - Motorcycle,"@(MSA_POP < 1000000) & (df.body_type.str.contains('Motorcycle'))",coef_smsa_mc
-util_smsa_hyb,MSA population less than 1 million - Hybrid,"@(MSA_POP < 1000000) & (df.fuel_type == 'Hybrid')",coef_smsa_hyb
-util_smsa_ev,MSA population less than 1 million - Electric,"@(MSA_POP < 1000000) & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_smsa_ev
+util_smsa_van,MSA population less than 1 million - Van,"@(MSA_POP < 1000000) & (df.body_type_num_coded==5)",coef_smsa_van
+util_smsa_suv,MSA population less than 1 million - SUV,"@(MSA_POP < 1000000) & (df.body_type_num_coded==4)",coef_smsa_suv
+util_smsa_pu,MSA population less than 1 million - Pickup,"@(MSA_POP < 1000000) & (df.body_type_num_coded==3)",coef_smsa_pu
+util_smsa_mc,MSA population less than 1 million - Motorcycle,"@(MSA_POP < 1000000) & (df.body_type_num_coded==2)",coef_smsa_mc
+util_smsa_hyb,MSA population less than 1 million - Hybrid,"@(MSA_POP < 1000000) & (df.fuel_type_num_coded==4)",coef_smsa_hyb
+util_smsa_ev,MSA population less than 1 million - Electric,"@(MSA_POP < 1000000) & ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1))",coef_smsa_ev
 util_smsa_age,MSA population less than 1 million - Age,"@(MSA_POP < 1000000) * df.age",coef_smsa_age
 #,Region Specific Constants,,
-util_sfo_van,SF and San Jose - Van,"@(CBSA == 'SFO') & (df.body_type.str.contains('Van'))",coef_sfo_van
-util_sfo_suv,SF and San Jose - SUV,"@(CBSA == 'SFO') & (df.body_type.str.contains('SUV'))",coef_sfo_suv
-util_sfo_pu,SF and San Jose - Pickup,"@(CBSA == 'SFO') & (df.body_type.str.contains('Pickup'))",coef_sfo_pu
-util_sfo_mc,SF and San Jose - Motorcycle,"@(CBSA == 'SFO') & (df.body_type.str.contains('Motorcycle'))",coef_sfo_mc
-util_sfo_hyb,SF and San Jose - Hybrid,"@(CBSA == 'SFO') & (df.fuel_type == 'Hybrid')",coef_sfo_hyb
-util_sfo_ev,SF and San Jose - Electric,"@(CBSA == 'SFO') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_sfo_ev
-util_sfo_age,SF and San Jose - Age,"@(CBSA == 'SFO') * df.age",coef_sfo_age
-util_san_van,San Diego - Van,"@(CBSA == 'SAN') & (df.body_type.str.contains('Van'))",coef_san_van
-util_san_suv,San Diego - SUV,"@(CBSA == 'SAN') & (df.body_type.str.contains('SUV'))",coef_san_suv
-util_san_pu,San Diego - Pickup,"@(CBSA == 'SAN') & (df.body_type.str.contains('Pickup'))",coef_san_pu
-util_san_mc,San Diego - Motorcycle,"@(CBSA == 'SAN') & (df.body_type.str.contains('Motorcycle'))",coef_san_mc
-util_san_hyb,San Diego - Hybrid,"@(CBSA == 'SAN') & (df.fuel_type == 'Hybrid')",coef_san_hyb
-util_san_ev,San Diego - Electric,"@(CBSA == 'SAN') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_san_ev
+util_san_van,San Diego - Van,"@(CBSA == 'SAN') & (df.body_type_num_coded==5)",coef_san_van
+util_san_suv,San Diego - SUV,"@(CBSA == 'SAN') & (df.body_type_num_coded==4)",coef_san_suv
+util_san_pu,San Diego - Pickup,"@(CBSA == 'SAN') & (df.body_type_num_coded==3)",coef_san_pu
+util_san_mc,San Diego - Motorcycle,"@(CBSA == 'SAN') & (df.body_type_num_coded==2)",coef_san_mc
+util_san_hyb,San Diego - Hybrid,"@(CBSA == 'SAN') & (df.fuel_type_num_coded==4)",coef_san_hyb
+util_san_ev,San Diego - Electric,"@(CBSA == 'SAN') & ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1))",coef_san_ev
 util_san_age,San Diego - Age,"@(CBSA == 'SAN') * df.age",coef_san_age
-util_atl_van,Atlanta - Van,"@(CBSA == 'ATL') & (df.body_type.str.contains('Van'))",coef_atl_van
-util_atl_suv,Atlanta - SUV,"@(CBSA == 'ATL') & (df.body_type.str.contains('SUV'))",coef_atl_suv
-util_atl_pu,Atlanta - Pickup,"@(CBSA == 'ATL') & (df.body_type.str.contains('Pickup'))",coef_atl_pu
-util_atl_mc,Atlanta - Motorcycle,"@(CBSA == 'ATL') & (df.body_type.str.contains('Motorcycle'))",coef_atl_mc
-util_atl_hyb,Atlanta - Hybrid,"@(CBSA == 'ATL') & (df.fuel_type == 'Hybrid')",coef_atl_hyb
-util_atl_ev,Atlanta - Electric,"@(CBSA == 'ATL') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_atl_ev
-util_atl_age,Atlanta - Age,"@(CBSA == 'ATL') * df.age",coef_atl_age
-util_sea_van,Seattle - Van,"@(CBSA == 'SEA') & (df.body_type.str.contains('Van'))",coef_sea_van
-util_sea_suv,Seattle - SUV,"@(CBSA == 'SEA') & (df.body_type.str.contains('SUV'))",coef_sea_suv
-util_sea_pu,Seattle - Pickup,"@(CBSA == 'SEA') & (df.body_type.str.contains('Pickup'))",coef_sea_pu
-util_sea_mc,Seattle - Motorcycle,"@(CBSA == 'SEA') & (df.body_type.str.contains('Motorcycle'))",coef_sea_mc
-util_sea_hyb,Seattle - Hybrid,"@(CBSA == 'SEA') & (df.fuel_type == 'Hybrid')",coef_sea_hyb
-util_sea_ev,Seattle - Electric,"@(CBSA == 'SEA') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_sea_ev
-util_sea_age,Seattle - Age,"@(CBSA == 'SEA') * df.age",coef_sea_age
-util_det_van,Detroit - Van,"@(CBSA == 'DET') & (df.body_type.str.contains('Van'))",coef_det_van
-util_det_suv,Detroit - SUV,"@(CBSA == 'DET') & (df.body_type.str.contains('SUV'))",coef_det_suv
-util_det_pu,Detroit - Pickup,"@(CBSA == 'DET') & (df.body_type.str.contains('Pickup'))",coef_det_pu
-util_det_mc,Detroit - Motorcycle,"@(CBSA == 'DET') & (df.body_type.str.contains('Motorcycle'))",coef_det_mc
-util_det_hyb,Detroit - Hybrid,"@(CBSA == 'DET') & (df.fuel_type == 'Hybrid')",coef_det_hyb
-util_det_ev,Detroit - Electric,"@(CBSA == 'DET') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_det_ev
-util_det_age,Detroit - Age,"@(CBSA == 'DET') * df.age",coef_det_age
-util_msp_van,Minneapolis - Van,"@(CBSA == 'MSP') & (df.body_type.str.contains('Van'))",coef_msp_van
-util_msp_suv,Minneapolis - SUV,"@(CBSA == 'MSP') & (df.body_type.str.contains('SUV'))",coef_msp_suv
-util_msp_pu,Minneapolis - Pickup,"@(CBSA == 'MSP') & (df.body_type.str.contains('Pickup'))",coef_msp_pu
-util_msp_mc,Minneapolis - Motorcycle,"@(CBSA == 'MSP') & (df.body_type.str.contains('Motorcycle'))",coef_msp_mc
-util_msp_hyb,Minneapolis - Hybrid,"@(CBSA == 'MSP') & (df.fuel_type == 'Hybrid')",coef_msp_hyb
-util_msp_ev,Minneapolis - Electric,"@(CBSA == 'MSP') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_msp_ev
-util_msp_age,Minneapolis - Age,"@(CBSA == 'MSP') * df.age",coef_msp_age
-util_dca_van,Washington DC - Van,"@(CBSA == 'DCA') & (df.body_type.str.contains('Van'))",coef_dca_van
-util_dca_suv,Washington DC - SUV,"@(CBSA == 'DCA') & (df.body_type.str.contains('SUV'))",coef_dca_suv
-util_dca_pu,Washington DC - Pickup,"@(CBSA == 'DCA') & (df.body_type.str.contains('Pickup'))",coef_dca_pu
-util_dca_mc,Washington DC - Motorcycle,"@(CBSA == 'DCA') & (df.body_type.str.contains('Motorcycle'))",coef_dca_mc
-util_dca_hyb,Washington DC - Hybrid,"@(CBSA == 'DCA') & (df.fuel_type == 'Hybrid')",coef_dca_hyb
-util_dca_ev,Washington DC - Electric,"@(CBSA == 'DCA') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_dca_ev
-util_dca_age,Washington DC - Age,"@(CBSA == 'DCA') * df.age",coef_dca_age
-util_oreg_van,Oregon - Van,"@(CBSA == 'OREG') & (df.body_type.str.contains('Van'))",coef_oreg_van
-util_oreg_suv,Oregon - SUV,"@(CBSA == 'OREG') & (df.body_type.str.contains('SUV'))",coef_oreg_suv
-util_oreg_pu,Oregon - Pickup,"@(CBSA == 'OREG') & (df.body_type.str.contains('Pickup'))",coef_oreg_pu
-util_oreg_mc,Oregon - Motorcycle,"@(CBSA == 'OREG') & (df.body_type.str.contains('Motorcycle'))",coef_oreg_mc
-util_oreg_hyb,Oregon - Hybrid,"@(CBSA == 'OREG') & (df.fuel_type == 'Hybrid')",coef_oreg_hyb
-util_oreg_ev,Oregon - Electric,"@(CBSA == 'OREG') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_oreg_ev
-util_oreg_age,Oregon - Age,"@(CBSA == 'OREG') * df.age",coef_oreg_age
-util_ohio_van,Ohio - Van,"@(CBSA == 'OHIO') & (df.body_type.str.contains('Van'))",coef_ohio_van
-util_ohio_suv,Ohio - SUV,"@(CBSA == 'OHIO') & (df.body_type.str.contains('SUV'))",coef_ohio_suv
-util_ohio_pu,Ohio - Pickup,"@(CBSA == 'OHIO') & (df.body_type.str.contains('Pickup'))",coef_ohio_pu
-util_ohio_mc,Ohio - Motorcycle,"@(CBSA == 'OHIO') & (df.body_type.str.contains('Motorcycle'))",coef_ohio_mc
-util_ohio_hyb,Ohio - Hybrid,"@(CBSA == 'OHIO') & (df.fuel_type == 'Hybrid')",coef_ohio_hyb
-util_ohio_ev,Ohio - Electric,"@(CBSA == 'OHIO') & ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_ohio_ev
-util_ohio_age,Ohio - Age,"@(CBSA == 'OHIO') * df.age",coef_ohio_age

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -1,13 +1,13 @@
 ﻿Label,Description,Expression,Coefficient
-util_ln_nmods,number of models available,"@np.log(1 + df.NumModels)",coef_ln_nmods
-util_ln_nmakes,number of makes available,"@np.log(1 + df.NumMakes)",coef_ln_nmakes
+util_ln_nmods,number of models available,"logged_models",coef_ln_nmods
+util_ln_nmakes,number of makes available,"logged_makes",coef_ln_nmakes
 util_mpg,miles per gallon (or equivalent),"@df.MPG",coef_mpg
 util_crange,Range for BEV (mi),"@df.Range",coef_crange
-util_crangeltwk,range less than average round trip distance to work,"@np.where((df.Range < df.avg_hh_dist_to_work * 2) & (df.fuel_type == 'BEV'), 1, 0)",coef_crangeltwk
-util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"@np.log(1+CHARGERS_PER_CAP) * ((df.fuel_type == 'PEV') | (df.fuel_type == 'BEV'))",coef_ln_chpc_ev
+util_crangeltwk,range less than average round trip distance to work,"(Range < (avg_hh_dist_to_work * 2)) & (fuel_type_num_coded==1)",coef_crangeltwk
+util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"logged_chargers_per_capita * ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_ln_chpc_ev
 #,autonomous vehicle related variables,,
-util_must_select_av,Must select autonomous vehicle if hh owns one,av_ownership & ~body_type.str.contains('-AV') & (num_hh_veh_owned == 0),coef_unavail
-util_must_select_av,Cannot select AV if hh does not own one,~av_ownership & body_type.str.contains('-AV'),coef_unavail
+util_must_select_av,Must select autonomous vehicle if hh owns one,av_ownership & ~is_av & (num_hh_veh_owned == 0),coef_unavail
+util_must_select_av,Cannot select AV if hh does not own one,~av_ownership & is_av,coef_unavail
 #,income related variables,,
 util_cprice0,New Purchase Price (2017$) Segmented by Income,"((income < 25000) & (income > -1)) * NewPrice",coef_cprice0
 util_cprice25,New Purchase Price (2017$) Segmented by Income,"((income < 50000) & (income >= 25000)) * NewPrice",coef_cprice25

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -143,10 +143,10 @@ util_smsa_hyb,MSA population less than 1 million - Hybrid,"@(MSA_POP < 1000000) 
 util_smsa_ev,MSA population less than 1 million - Electric,"@(MSA_POP < 1000000) & ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1))",coef_smsa_ev
 util_smsa_age,MSA population less than 1 million - Age,"@(MSA_POP < 1000000) * df.age",coef_smsa_age
 #,Region Specific Constants,,
-util_san_van,San Diego - Van,"@(CBSA == 'SAN') & (df.body_type_num_coded==5)",coef_san_van
-util_san_suv,San Diego - SUV,"@(CBSA == 'SAN') & (df.body_type_num_coded==4)",coef_san_suv
-util_san_pu,San Diego - Pickup,"@(CBSA == 'SAN') & (df.body_type_num_coded==3)",coef_san_pu
-util_san_mc,San Diego - Motorcycle,"@(CBSA == 'SAN') & (df.body_type_num_coded==2)",coef_san_mc
-util_san_hyb,San Diego - Hybrid,"@(CBSA == 'SAN') & (df.fuel_type_num_coded==4)",coef_san_hyb
-util_san_ev,San Diego - Electric,"@(CBSA == 'SAN') & ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1))",coef_san_ev
-util_san_age,San Diego - Age,"@(CBSA == 'SAN') * df.age",coef_san_age
+util_san_van,San Diego - Van,"@(df.SAN) & (df.body_type_num_coded==5)",coef_san_van
+util_san_suv,San Diego - SUV,"@(df.SAN) & (df.body_type_num_coded==4)",coef_san_suv
+util_san_pu,San Diego - Pickup,"@(df.SAN) & (df.body_type_num_coded==3)",coef_san_pu
+util_san_mc,San Diego - Motorcycle,"@(df.SAN) & (df.body_type_num_coded==2)",coef_san_mc
+util_san_hyb,San Diego - Hybrid,"@(df.SAN) & (df.fuel_type_num_coded==4)",coef_san_hyb
+util_san_ev,San Diego - Electric,"@(df.SAN) & ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1))",coef_san_ev
+util_san_age,San Diego - Age,"@(df.SAN) * df.age",coef_san_age


### PR DESCRIPTION
Editing configs so recoding the fuel and body types as integers to save memory. Requires [this pull request](https://github.com/SANDAG/activitysim/pull/66) to be merged into the BayDAG_estimation branch of the ActivitySim source code.