### PR TITLE
Update ABM3 GUI to select land use scenario

### DIFF
--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,7 +207,7 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            option=tkinter.OptionMenu(body,var,value=luOptionList,command=self.setLU)
+            option=tkinter.OptionMenu(body,var,*luOptionList,value=lu,command=self.setLU)
 
             option.config(width=50)
             option.grid(row=current_row, column=1)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -47,7 +47,7 @@ class SelectStudyYears(tkinter.Frame):
 
 
 class CreateScenarioGUI(tkinter.Frame):
-        def __init__(self, root, emme_version = "4.3.7", year = "2016", geo = "1", lu = "S0"):
+        def __init__(self, root, emme_version = "4.3.7", year = "2022", geo = "1", lu = "S0"):
             tkinter.Frame.__init__(self, root, border=5)
             body = tkinter.Frame(self)
             body.pack(fill=constants.X, expand=1)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -47,7 +47,7 @@ class SelectStudyYears(tkinter.Frame):
 
 
 class CreateScenarioGUI(tkinter.Frame):
-        def __init__(self, root, emme_version = "4.3.7", year = "2016", geo = "1", lu = "DS41"):
+        def __init__(self, root, emme_version = "4.3.7", year = "2016", geo = "1", lu = "S0"):
             tkinter.Frame.__init__(self, root, border=5)
             body = tkinter.Frame(self)
             body.pack(fill=constants.X, expand=1)
@@ -55,10 +55,24 @@ class CreateScenarioGUI(tkinter.Frame):
             body.grid_columnconfigure(1, weight=2)
 
             #Define land use options
-            self.lu_options = {"DS41": {"name": "Baseline",
-                                        "years": ["2022", "2025nb", "2030nb", "2035nb", "2040nb", "2050nb"]},
-                               "DS42": {"name": "Sustainable Community Strategy",
-                                        "years": ["2016", "2023", "2025", "2026", "2029", "2030", "2032", "2035", "2040", "2050"]}}
+            self.lu_options = {
+                "S0": {
+                    "name": "Baseline",
+                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                },
+                "S1": {
+                    "name": "Baseline + RHNA Adjustment",
+                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                },
+                "S2": {
+                    "name": "Sustainable Community Strategy",
+                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                },
+                "S3": {
+                    "name": "SCS with Higher Density",
+                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                }
+            }
 
             self.root = root
             self.emme_version = emme_version
@@ -66,11 +80,11 @@ class CreateScenarioGUI(tkinter.Frame):
             self.geo = geo            
             self.lu = lu
  
-            if self.year not in self.lu_options[self.lu]["years"]:
-                if self.year in self.lu_options["DS41"]["years"]:
-                    self.lu = "DS41"
-                else:
-                    self.lu = "DS42"
+            # if self.year not in self.lu_options[self.lu]["years"]:
+            #     if self.year in self.lu_options["DS41"]["years"]:
+            #         self.lu = "DS41"
+            #     else:
+            #         self.lu = "DS42"
 
             yearOptionList = []
             for lu in self.lu_options:

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -58,19 +58,23 @@ class CreateScenarioGUI(tkinter.Frame):
             self.lu_options = {
                 "S0": {
                     "name": "Baseline",
-                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                    "location": "T:\socioec\Current_Projects\SR15\S0\version16",
+                    "years": ["2022", "2026", "2029", "2035", "2050"]
                 },
                 "S1": {
                     "name": "Baseline + RHNA Adjustment",
-                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                    "location": "T:\socioec\Current_Projects\SR15\S1\version12",
+                    "years": ["2022", "2035"]
                 },
                 "S2": {
                     "name": "Sustainable Community Strategy",
-                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                    "location": "T:\socioec\Current_Projects\SR15\S2\version17",
+                    "years": ["2022", "2035"]
                 },
                 "S3": {
                     "name": "SCS with Higher Density",
-                    "years": ["2022", "2026", "2029", "2032", "2035", "2040", "2045", "2050"]
+                    "location": "T:\socioec\Current_Projects\SR15\S3\version18",
+                    "years": ["2035"]
                 }
             }
 
@@ -394,16 +398,21 @@ class CreateScenarioGUI(tkinter.Frame):
         def executeBatch(self, type):
             self.popup.destroy()
             if type=="scenario":
-                commandstr = u"create_scenario.cmd %s %s %s %s" % (
+                if self.year == 2035:
+                    lu_input_path = os.path.join(self.lu_options[self.lu]["location"], "abm_csv", "processed", "2035_baseline")
+                else:
+                    lu_input_path = os.path.join(self.lu_options[self.lu]["location"], "abm_csv", "processed", str(self.year))
+                commandstr = u"create_scenario.cmd %s %s %s %s %s" % (
                     self.scenariopath.get(),
                     self.year,
                     self.networkpath.get(),
-                    self.emme_version
+                    self.emme_version,
+                    lu_input_path
                 )
                 os.chdir(self.releaseDir+"\\"+self.version+'\\')
                 os.system(commandstr)
                 #self.update_property("version=version_14_2_2", "version=version_14_2_2\nLU version=" + self.lu)
-                self.update_property("version=version_14_3_0", "version=version_14_3_0\nLU version=" + self.lu)
+                self.update_property("version=version_15_0_0", "version=version_15_0_0\nLU version=" + self.lu)
                 self.update_property("geographyID=1", "geographyID=" + self.geo.get())
             elif type=="study":
                 studyyears = self.studyyears.get().split(',')

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,7 +207,7 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            option=tkinter.OptionMenu(body,var,*luOptionList,value=lu,command=self.setLU)
+            option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
 
             option.config(width=50)
             option.grid(row=current_row, column=1)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,10 +207,11 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            #option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
+            print(luOptionList)
+            option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
 
-            #option.config(width=50)
-            #option.grid(row=current_row, column=1)
+            option.config(width=50)
+            option.grid(row=current_row, column=1)
             current_row += 1
 
             tkinter.Label(body, text=u"Geography ID", font=("Helvetica", 8, 'bold')).grid(row=current_row)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,7 +207,6 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            print(luOptionList)
             option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
 
             option.config(width=50)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -58,22 +58,22 @@ class CreateScenarioGUI(tkinter.Frame):
             self.lu_options = {
                 "S0": {
                     "name": "Baseline",
-                    "location": "T:\socioec\Current_Projects\SR15\S0\version16",
+                    "location": r"T:\socioec\Current_Projects\SR15\S0\version16",
                     "years": ["2022", "2026", "2029", "2035", "2050"]
                 },
                 "S1": {
                     "name": "Baseline + RHNA Adjustment",
-                    "location": "T:\socioec\Current_Projects\SR15\S1\version12",
+                    "location": r"T:\socioec\Current_Projects\SR15\S1\version12",
                     "years": ["2022", "2035"]
                 },
                 "S2": {
                     "name": "Sustainable Community Strategy",
-                    "location": "T:\socioec\Current_Projects\SR15\S2\version17",
+                    "location": r"T:\socioec\Current_Projects\SR15\S2\version17",
                     "years": ["2022", "2035"]
                 },
                 "S3": {
                     "name": "SCS with Higher Density",
-                    "location": "T:\socioec\Current_Projects\SR15\S3\version18",
+                    "location": r"T:\socioec\Current_Projects\SR15\S3\version18",
                     "years": ["2035"]
                 }
             }

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -208,7 +208,7 @@ class CreateScenarioGUI(tkinter.Frame):
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
             option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
-
+            option.config(text = self.lu)
             option.config(width=50)
             option.grid(row=current_row, column=1)
             current_row += 1

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,7 +207,7 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            option=tkinter.OptionMenu(body,var,*luOptionList,value='0',command=self.setLU)
+            option=tkinter.OptionMenu(body,var,value=luOptionList,command=self.setLU)
 
             option.config(width=50)
             option.grid(row=current_row, column=1)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,10 +207,10 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
-            option.config(text = self.lu)
-            option.config(width=50)
-            option.grid(row=current_row, column=1)
+            #option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
+
+            #option.config(width=50)
+            #option.grid(row=current_row, column=1)
             current_row += 1
 
             tkinter.Label(body, text=u"Geography ID", font=("Helvetica", 8, 'bold')).grid(row=current_row)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -64,7 +64,7 @@ class CreateScenarioGUI(tkinter.Frame):
                 "S1": {
                     "name": "Baseline + RHNA Adjustment",
                     "location": r"T:\socioec\Current_Projects\SR15\S1\version12",
-                    "years": ["2022", "2035"]
+                    "years": ["2022", "2026", "2029", "2035"]
                 },
                 "S2": {
                     "name": "Sustainable Community Strategy",

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -107,7 +107,7 @@ class CreateScenarioGUI(tkinter.Frame):
                 self.releaseDir=os.path.abspath(os.path.join(os.path.dirname(sys.executable), '..', '..'))
             else:
                 self.releaseDir=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
-            self.defaultScenarioDir="T:\\projects\\sr15"
+            self.defaultScenarioDir="T:\\projects\\sr15\\MyRun"
             self.defaultNetworkDir="T:\\RTP\\2021RP\\2021rp_final\\network_build"
 
             current_row = 0
@@ -398,7 +398,7 @@ class CreateScenarioGUI(tkinter.Frame):
         def executeBatch(self, type):
             self.popup.destroy()
             if type=="scenario":
-                if self.year == 2035:
+                if self.year == "2035":
                     lu_input_path = os.path.join(self.lu_options[self.lu]["location"], "abm_csv", "processed", "2035_baseline")
                 else:
                     lu_input_path = os.path.join(self.lu_options[self.lu]["location"], "abm_csv", "processed", str(self.year))

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -112,7 +112,7 @@ class CreateScenarioGUI(tkinter.Frame):
             self.buttonVar= tkinter.IntVar(root)
             self.yButton=tkinter.Radiobutton(body, text="Yes", variable=self.buttonVar, value=1, command=self.initStudy)
             self.nButton=tkinter.Radiobutton(body, text="No", variable=self.buttonVar, value=0,command=self.initStudy)
-            tkinter.Label(body, text=u"Release Version 14.3.0\n"+divider, font=("Helvetica", 11, 'bold'), width=50, fg='royal blue').grid(row=current_row,columnspan=5)
+            tkinter.Label(body, text=u"Release Version 15.0.0\n"+divider, font=("Helvetica", 11, 'bold'), width=50, fg='royal blue').grid(row=current_row,columnspan=5)
             current_row += 1
             tkinter.Label(body, text=u"Create an ABM Work Space", font=("Helvetica", 10, 'bold')).grid(row=current_row,columnspan=n_columns)
             current_row += 1

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -207,7 +207,7 @@ class CreateScenarioGUI(tkinter.Frame):
             for lu in self.lu_options:
                 if self.year in self.lu_options[lu]["years"]:
                     luOptionList.append(lu + '-' + self.lu_options[lu]["name"])
-            option=tkinter.OptionMenu(body,var,*luOptionList,command=self.setLU)
+            option=tkinter.OptionMenu(body,var,*luOptionList,value='0',command=self.setLU)
 
             option.config(width=50)
             option.grid(row=current_row, column=1)

--- a/src/main/resources/create_scenario.cmd
+++ b/src/main/resources/create_scenario.cmd
@@ -6,11 +6,13 @@ if "%1"=="" goto usage
 if "%2"=="" goto usage
 if "%3"=="" goto usage
 if "%4"=="" goto usage
+if "%5"=="" goto usage
 
 set SCENARIO_FOLDER=%1
 set YEAR=%2
 set NETWORKDIR=%3
 set EMME_VERSION=%4
+set LANDUSE_INPUT_PATH=%5
 
 @echo creating scenario folders
 set FOLDERS=input application bin conf input_truck logFiles output python report sql uec analysis visualizer visualizer\outputs\summaries input_checker src src\asim src\asim-cvm
@@ -76,6 +78,10 @@ xcopy /Y .\common\input\input_checker\"*.*" %SCENARIO_FOLDER%
 rem copy network inputs
 call copy_networks.cmd %NETWORKDIR% %SCENARIO_FOLDER%\input
 
+rem copying land use inputs
+xcopy /Y %LANDUSE_INPUT_PATH%\"households.csv" %SCENARIO_FOLDER%\input
+xcopy /Y %LANDUSE_INPUT_PATH%\"persons.csv" %SCENARIO_FOLDER%\input
+xcopy /Y %LANDUSE_INPUT_PATH%\"mgra15_based_input"%YEAR%".csv" %SCENARIO_FOLDER%\input
 
 rem copy analysis templates
 @echo copy analysis templates


### PR DESCRIPTION
- The user can now select a land use scenario, which will copy the inputs for the desired year and scenario from the filepath defined [here](https://github.com/SANDAG/ABM/blob/ABM3_gui_lu/src/main/python/pythonGUI/createStudyAndScenario.py#L58). A land use scenario is only available for a given year if the year is listed under `"years"` for the scenario in `self.lu_options` (I based this on what was present at the time).
- The displayed release version is updated from 14.3.0 to 15.0.0.
- The default directory from the scenario was updated to prevent everything being copied into T:\projects\sr15 by mistake.