### PR TITLE
Fix onboard tour mode choice coefficient

### DIFF
--- a/src/asim/configs/resident/tour_mode_choice_coefficients.csv
+++ b/src/asim/configs/resident/tour_mode_choice_coefficients.csv
@@ -756,3 +756,4 @@ coef_calib_autosufficienthhin_ESCOOTER_school,-2.0,F
 coef_calib_autosufficienthhin_EBIKE_school,-2.363534838614524,F
 coef_calib_autosufficienthhin_ESCOOTER_atwork,-4.0,F
 coef_calib_autosufficienthhin_EBIKE_atwork,-2.67253074,F
+coef_calib_onboard,-0.141810560200827,F

--- a/src/asim/configs/resident/trip_mode_choice_coefficients.csv
+++ b/src/asim/configs/resident/trip_mode_choice_coefficients.csv
@@ -1434,4 +1434,3 @@ coef_calib_tourescooterjointtour0_ESCOOTER_maint,0.0,F
 coef_calib_tourescooterjointtour1_ESCOOTER_disc,-28.0,F
 coef_calib_tourescooterjointtour1_ESCOOTER_maint,-28.0,F
 coef_calib_flexfleet,0.0,F
-coef_calib_onboard,-0.141810560200827,F


### PR DESCRIPTION
`coef_calib_onboard` was mistakenly defined in the coefficient file for trip mode choice and not tour mode choice. This fixes that.