### PR TITLE
Decreased coef_calib_onboard in resident tour mode choice

### DIFF
--- a/src/asim/configs/resident/tour_mode_choice_coefficients.csv
+++ b/src/asim/configs/resident/tour_mode_choice_coefficients.csv
@@ -756,4 +756,4 @@ coef_calib_autosufficienthhin_ESCOOTER_school,-2.0,F
 coef_calib_autosufficienthhin_EBIKE_school,-2.363534838614524,F
 coef_calib_autosufficienthhin_ESCOOTER_atwork,-4.0,F
 coef_calib_autosufficienthhin_EBIKE_atwork,-2.67253074,F
-coef_calib_onboard,-0.210972033766198,F
+coef_calib_onboard,-0.293475781,F


### PR DESCRIPTION
## Proposed changes

The value of coef_calib_onboard in resident tour mode choice was decreased.

## Impact

A 10% sample of of the resident model resulted in 7522 transit tours. After multiplying by 10 this is only 0.9% below the target of 75,912.

## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Run of resident model at a 10% sample.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

