### PR TITLE
Add common config arg to xborder asim call

### DIFF
--- a/src/main/resources/runSandagAbm_ActivitySimXborderWaitModel.cmd
+++ b/src/main/resources/runSandagAbm_ActivitySimXborderWaitModel.cmd
@@ -50,7 +50,7 @@ MD crossborder
 CD ..
 
 :: Run xborder wait time model
-%PYTHON3% src/asim/scripts/xborder/cross_border_model.py -w -c src/asim/configs/crossborder -d input -o output/crossborder || exit /b 2
+%PYTHON3% src/asim/scripts/xborder/cross_border_model.py -w -c src/asim/configs/crossborder -c src/asim/configs/common -d input -o output/crossborder || exit /b 2
 
 ECHO ActivitySim Crossborder wait time model run complete!!
 ECHO %startTime%%Time%

--- a/src/main/resources/runSandagAbm_Preprocessing.cmd
+++ b/src/main/resources/runSandagAbm_Preprocessing.cmd
@@ -72,7 +72,7 @@ if %ITERATION% equ 1 (
     %PYTHON3% src/asim/scripts/airport/createPOIomx.py %PROJECT_DIRECTORY% %SCENYEAR% || goto error
 
     ECHO Running xborder model pre-processing
-    %PYTHON3% src/asim/scripts/xborder/cross_border_model.py -p -c src/asim/configs/crossborder -d input -o output/crossborder || goto error
+    %PYTHON3% src/asim/scripts/xborder/cross_border_model.py -p -c src/asim/configs/crossborder -c src/asim/configs/common -d input -o output/crossborder || goto error
     %PYTHON3% src/asim/scripts/xborder/createPMSAomx.py %PROJECT_DIRECTORY% || goto error
 
     ECHO Running visitor model pre-processing


### PR DESCRIPTION
## Proposed changes

Add the common config directory to the arguments for cross_border_model.py in runSandagAbm_Preprocessing.cmd and runSandagAbm_ActivitySimXborderWaitModel.cmd, needed because xborder model now uses common/constants.yaml

## Impact

Fixes error when calling asim preprocessing or xborder wait

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Untested but currently running

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
