### PR TITLE
Add common config arg to xborder wait call

### DIFF
--- a/src/asim/scripts/xborder/cross_border_model.py
+++ b/src/asim/scripts/xborder/cross_border_model.py
@@ -825,7 +825,7 @@ if __name__ == '__main__':
             print('UPDATING POE WAIT TIMES: ITER {0}'.format(i))
             process = subprocess.Popen([
                     'python', '-u', 'src/asim/simulation.py', '-s',
-                    'wait_time_mode.yaml', '-c', config_dir ,'-o', output_dir, '-d', data_dir, '-d', 'output/skims'],
+                    'wait_time_mode.yaml', '-c', config_dir, '-c', common_config_dir,'-o', output_dir, '-d', data_dir, '-d', 'output/skims'],
                 stdout=sys.stdout, stderr=subprocess.PIPE)
             _, stderr = process.communicate()
             if process.returncode != 0:


### PR DESCRIPTION
## Proposed changes

Add common config directory to arguments when calling simulation.py to run crossborder wait time model.

## Impact

Fixes error when calling xborder wait

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran xborder wait model with no errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
