### PR TITLE
Delete old files when rebuilding release

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -22,6 +22,9 @@ if exist %ROOT% (
 
 :build
 
+@REM Delete common directory first so deleted files are not preserved
+if exist %ROOT%\common rmdir /s /q %ROOT%\common
+
 @REM Copy scenario creation scripts
 for /f "tokens=*" %%i in (build_create_scenario_scripts.txt) DO (
     xcopy /Y .\src\main\resources\%%i %ROOT%


### PR DESCRIPTION
## Proposed changes

When running build.cmd to rebuild an existing release, delete the existing version_x_x_x\common directory to remove any old files that may have been deleted in recent commits.

## Impact

Prevents issues caused by files deleted on repo persisting in release

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Built new release, added unwanted file to release directory, rebuilt release, confirmed unwanted file was removed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
