### PR TITLE
Remove unused input_truck and visualizer folders in scenario

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -376,7 +376,6 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         drive, path_no_drive = os.path.splitdrive(self._path)
         path_forward_slash = path_no_drive.replace("\\", "/")
         input_dir = _join(self._path, "input")
-        input_truck_dir = _join(self._path, "input_truck")
         output_dir = _join(self._path, "output")
         validation_dir = _join(self._path, "analysis/validation")
         main_emmebank = _eb.Emmebank(_join(self._path, "emme_project", "Database", "emmebank"))

--- a/src/main/emme/toolbox/model/external_internal.py
+++ b/src/main/emme/toolbox/model/external_internal.py
@@ -43,7 +43,7 @@
     input_dir = os.path.join(main_directory, "input")
     base_scenario = modeller.scenario
     external_internal = modeller.tool("sandag.model.external_internal")
-    external_internal(input_dir, input_truck_dir, base_scenario)
+    external_internal(input_dir, base_scenario)
 """
 
 TOOLBOX_ORDER = 61

--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -156,7 +156,7 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
         if initialize:
             # make sure that all of the root directories are created
             root_dirs = [
-                "application", "bin", "conf", "emme_project", "input", "input_truck",
+                "application", "bin", "conf", "emme_project", "input",
                 "logFiles", "output", "python", "report", "sql", "uec"
             ]
             for name in root_dirs:
@@ -189,8 +189,6 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
         self._report = []
         self._stats = {"size": 0, "count": 0}
         if not file_masks:
-            # suggested defaults: "application", "bin", "input", "input_truck", "uec",
-            #                     "output\\iter*", "output\\*_1.csv", "output\\*_2.csv"
             file_masks = []
         # prepend the src dir to the project masks
         file_masks = [_join(local_dir, p) for p in file_masks]

--- a/src/main/resources/create_scenario.cmd
+++ b/src/main/resources/create_scenario.cmd
@@ -17,7 +17,7 @@ set LANDUSE_INPUT_PATH=%5
 set SUFFIX=%6
 
 @echo creating scenario folders
-set FOLDERS=input application bin conf input_truck logFiles output python report sql uec analysis visualizer visualizer\outputs\summaries input_checker src src\asim src\asim-cvm
+set FOLDERS=input application bin conf logFiles output python report sql uec analysis input_checker src src\asim src\asim-cvm
 for %%i in (%FOLDERS%) do (
 md %SCENARIO_FOLDER%\%%i)
 
@@ -38,8 +38,6 @@ xcopy /Y .\common\bin\"*.*" %SCENARIO_FOLDER%\bin
 rem xcopy /Y .\conf\%YEAR%\"*.*" %SCENARIO_FOLDER%\conf
 xcopy /Y .\common\conf\"*.*" %SCENARIO_FOLDER%\conf
 xcopy /Y .\common\output\"*.*" %SCENARIO_FOLDER%\output
-xcopy /s/Y .\common\visualizer %SCENARIO_FOLDER%\visualizer
-xcopy /s/Y .\dependencies.* %SCENARIO_FOLDER%\visualizer
 xcopy /Y/s/E .\common\input\input_checker\"*.*" %SCENARIO_FOLDER%\input_checker
 xcopy /Y/s/E .\common\src\asim\"*.*" %SCENARIO_FOLDER%\src\asim
 xcopy /Y/s/E .\common\src\asim-cvm\"*.*" %SCENARIO_FOLDER%\src\asim-cvm
@@ -53,28 +51,18 @@ xcopy /Y .\common\input\geography\"*.*" %SCENARIO_FOLDER%\input
 xcopy /Y .\common\input\geography\mgra\"*.*" %SCENARIO_FOLDER%\input
 xcopy /Y .\common\input\geography\pmsa\"*.*" %SCENARIO_FOLDER%\input
 xcopy /Y .\common\input\geography\taz\"*.*" %SCENARIO_FOLDER%\input
-rem copy ctm paramter tables to input folder
-xcopy /Y .\common\input\ctm\"*.*" %SCENARIO_FOLDER%\input
 rem copy common model files to input folder
 xcopy /Y .\common\input\model\"*.*" %SCENARIO_FOLDER%\input
-rem copy common truck files to input_truck folder
-xcopy /Y .\common\input\truck\"*.*" %SCENARIO_FOLDER%\input_truck
-rem copy airport input files
-xcopy /Y .\common\input\airports\"*.*" %SCENARIO_FOLDER%\input
 rem copy ei input files
 xcopy /Y .\common\input\ei\"*.*" %SCENARIO_FOLDER%\input
 rem copy ie input files
 xcopy /Y .\common\input\ie\"*.*" %SCENARIO_FOLDER%\input
 rem copy ee input files
 xcopy /Y .\common\input\ee\"*.*" %SCENARIO_FOLDER%\input
-rem copy emfact input files
-xcopy /Y .\common\input\emfact\"*.*" %SCENARIO_FOLDER%\input
 rem copy special event input files
 xcopy /Y .\common\input\specialevent\"*.*" %SCENARIO_FOLDER%\input
 rem copy xborder input files
 xcopy /Y .\common\input\xborder\"*.*" %SCENARIO_FOLDER%\input
-rem copy visitor input files
-xcopy /Y .\common\input\visitor\"*.*" %SCENARIO_FOLDER%\input
 rem copy input checker config files
 xcopy /Y .\common\input\input_checker\"*.*" %SCENARIO_FOLDER%
 rem copy network inputs


### PR DESCRIPTION
## Proposed changes

Removes code that creates and copies files to input_truck and visualizer folders, as these are unused and empty. Also removed references to some previously removed input folders.

## Impact

Code and directory cleanliness

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Untested, but removed folders are not referenced elsewhere in the code

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
