### PR TITLE
Get maximum disk usage, update disk space check

### DIFF
--- a/src/asim/configs/resident/settings_mp.yaml
+++ b/src/asim/configs/resident/settings_mp.yaml
@@ -77,6 +77,7 @@ models:
   # - write_to_datalake
   - update_tables
   - write_tables
+  # - check_disk_usage # Uncomment to get max disk usage at end of iteration 3 resident model
 
 
 multiprocess_steps:

--- a/src/asim/extensions/__init__.py
+++ b/src/asim/extensions/__init__.py
@@ -6,3 +6,4 @@ from . import airport_returns
 # from . import write_to_datalake
 from . import update_tables
 from . import adjust_auto_operating_cost
+from . import check_disk_usage

--- a/src/asim/extensions/check_disk_usage.py
+++ b/src/asim/extensions/check_disk_usage.py
@@ -1,0 +1,16 @@
+# ActivitySim
+# See full license in LICENSE.txt.
+import os
+import logging
+import win32com.client as win32
+
+from activitysim.core import inject
+
+logger = logging.getLogger("activitysim")
+
+@inject.step()
+def check_disk_usage():
+    output_dir = inject.get_injectable("output_dir")
+    path = os.path.abspath(os.path.join(output_dir, "..", ".."))
+    disk_usage = win32.Dispatch('Scripting.FileSystemObject').GetFolder(path).Size
+    logger.info("Disk space usage: %f GB" % (disk_usage / (1024 ** 3)))

--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -861,6 +861,10 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 
         # UPLOAD DATA AND SWITCH PATHS
         if useLocalDrive:
+            # # Uncomment to get disk usage at end of run
+            # # Note that max disk usage occurs in resident model, not at end of run
+            # disk_usage = win32.Dispatch('Scripting.FileSystemObject').GetFolder(self._path).Size
+            # _m.logbook_write("Disk space usage: %f GB" % (disk_usage / (1024 ** 3)))
             file_manager("UPLOAD", main_directory, username, scenario_id,
                          delete_local_files=not skipDeleteIntermediateFiles)
             self._path = main_directory

--- a/src/main/resources/sandag_abm.properties
+++ b/src/main/resources/sandag_abm.properties
@@ -65,7 +65,7 @@ RunModel.skipDataLoadRequest = true
 RunModel.skipDeleteIntermediateFiles = false
 RunModel.MatrixPrecision = 0.0005
 # minimual space (MB) on C drive
-RunModel.minSpaceOnC = 400
+RunModel.minSpaceOnC = 430
 
 TNC.totalThreads = 10
 


### PR DESCRIPTION
## Proposed changes

Get scenario folder disk usage at end of resident model and end of scenario run before copying to T drive. Pipeline files are cleared at end of resident model, so max usage is expected to be at the end of iteration 3 resident before clearing pipeline. Disk usage check is commented out by default.

Current max disk usage for 2035 build is 422gb. Updated disk space check to 430gb to leave some breathing room.

## Impact

Prevents starting runs without sufficient C drive space

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran for 2035 build to get maximum disk usage

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
