### PR TITLE
Reduce EV Charger Sensitivity

### DIFF
--- a/src/asim/configs/resident/vehicle_type_choice.yaml
+++ b/src/asim/configs/resident/vehicle_type_choice.yaml
@@ -130,3 +130,4 @@ CONSTANTS:
   # chargers per cap used in vehicle type model estimation
   # CHARGERS_PER_CAP: 0.000721205
   scenarioYear: 2022
+  chargerSensitivityDecayFactor: -0.08245202

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -4,7 +4,7 @@ util_ln_nmakes,number of makes available,"logged_makes",coef_ln_nmakes
 util_mpg,miles per gallon (or equivalent),"@df.MPG",coef_mpg
 util_crange,Range for BEV (mi),"@df.Range",coef_crange
 util_crangeltwk,range less than average round trip distance to work,"(Range < (avg_hh_dist_to_work * 2)) & (fuel_type_num_coded==1)",coef_crangeltwk
-util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"@logged_chargers_per_capita * ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1)) * np.exp(chargerSensitivityDecayFactor*(scenarioYear-2022))",coef_ln_chpc_ev
+util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"@df.logged_chargers_per_capita * ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1)) * np.exp(chargerSensitivityDecayFactor*(scenarioYear-2022))",coef_ln_chpc_ev
 #,autonomous vehicle related variables,,
 util_must_select_av,Must select autonomous vehicle if hh owns one,av_ownership & ~is_av & (num_hh_veh_owned == 0),coef_unavail
 util_must_select_av,Cannot select AV if hh does not own one,~av_ownership & is_av,coef_unavail

--- a/src/asim/configs/resident/vehicle_type_choice_op4.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4.csv
@@ -4,7 +4,7 @@ util_ln_nmakes,number of makes available,"logged_makes",coef_ln_nmakes
 util_mpg,miles per gallon (or equivalent),"@df.MPG",coef_mpg
 util_crange,Range for BEV (mi),"@df.Range",coef_crange
 util_crangeltwk,range less than average round trip distance to work,"(Range < (avg_hh_dist_to_work * 2)) & (fuel_type_num_coded==1)",coef_crangeltwk
-util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"logged_chargers_per_capita * ((fuel_type_num_coded==5) | (fuel_type_num_coded==1))",coef_ln_chpc_ev
+util_ln_chpc_ev,ln(1+number of chargers per capita in MSA/state),"@logged_chargers_per_capita * ((df.fuel_type_num_coded==5) | (df.fuel_type_num_coded==1)) * np.exp(chargerSensitivityDecayFactor*(scenarioYear-2022))",coef_ln_chpc_ev
 #,autonomous vehicle related variables,,
 util_must_select_av,Must select autonomous vehicle if hh owns one,av_ownership & ~is_av & (num_hh_veh_owned == 0),coef_unavail
 util_must_select_av,Cannot select AV if hh does not own one,~av_ownership & is_av,coef_unavail

--- a/src/asim/configs/resident/vehicle_type_choice_op4_coefficients.csv
+++ b/src/asim/configs/resident/vehicle_type_choice_op4_coefficients.csv
@@ -5,7 +5,7 @@ coef_ln_nmakes,.247,F
 coef_mpg,0.007,F
 coef_crange,0.018,F
 coef_crangeltwk,-0.781,F
-coef_ln_chpc_ev,1686.871,F
+coef_ln_chpc_ev,354.347,F
 coef_cprice0,-0.00010,F
 coef_cprice25,-0.00009,F
 coef_cprice50,-0.00008,F
@@ -188,9 +188,9 @@ coef_ohio_mc,0.140,F
 coef_ohio_hyb,-0.142,F
 coef_ohio_ev,-1.590,F
 coef_ohio_age,-0.008,F
-coef_calib_pev_2022,-2.55829,F
-coef_calib_bev_2022,-1.70775,F
-coef_calib_pev_2035,-12.8722,F
-coef_calib_bev_2035,-12.75503,F
-coef_calib_pev_2050,-67.86506714368133,F
-coef_calib_bev_2050,-68.87800114333946,F
+coef_calib_pev_2022,0.56468,F
+coef_calib_bev_2022,1.42228,F
+coef_calib_pev_2035,0.86656,F
+coef_calib_bev_2035,0.98343,F
+coef_calib_pev_2050,0.36963,F
+coef_calib_bev_2050,-0.64752,F


### PR DESCRIPTION
## Proposed changes

During the tests of the 2025 Regional Plan initial concept, it was found that increasing the number of EV chargers from 30,000 to 40,000 increased the share of vehicles that are EVs from 25% (what the no build scenario was calibrated to) to 97%. This pull request has the following changes:
- Reduces the EV ownership sensitivity to the number of chargers
- Edit the utility expression to have the sensitivity decrease exponentially over time (see below for explanation)
- Recalibrate the 2022, 2035, and 2050 shares to match the targets set by planning staff

## Impact

A rerun of the recent 2035 no build and build runs found that the increase in EVs was from 25% to 33%, which is much more realistic and consistent with the literature we found (see below for explanation). It should be noted that the build run also included rebates for EV purchases, which will increase the EV share as well.

Vehicle type distribution before the change:
![image](https://github.com/user-attachments/assets/26a57044-b56b-4544-82e1-ff56b335cd7a)

Vehicle type distribution after the change:
![image](https://github.com/user-attachments/assets/2dd8f04b-41ed-462f-948a-2e881c0cff17)


## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Multiple calibration runs to get the no-build EV shares to the targets set by planners
- [x] Rerunning the 2035 no build and build runs with this change to ensure that the sensitivity did indeed decrease (see charts above)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

The formula for direct elasticity in a multinomial logit model is as follows (from @jfdman):

$\textnormal{Direct Elasticity} = (1 - \textnormal{Current Share})\times\textnormal{coefficient}\times\textnormal{value}$

Given that the previous coefficient value was 1686.871, the no-build EV share was calibrated to 25%, and there were 0.0088 EV chargers per capita, the elasticity would have been:

$(1-0.25)\times1686.871\times\ln{(1+0.0088)}=11.08$

This is way too high, especially as a [paper](https://www.journals.uchicago.edu/doi/full/10.1086/689702?t&utm_source=perplexity#_i38) found in a literature review by @bhargavasana suggests that the elasticity should be closer to 0.8. Further, planners had requested that the modelers assume the number of chargers would grow 11% annually, which is an exponential increase. Given this along with the fact that the number chargers per capita are within a range such that $ln(1+x)$ is practically linear with respect to $x$ for every scenario year, the elasticity of EV ownership will increase exponentially for future years (and @jfdman suggested that if anything, it should decrease over time as public chargers become more ubiquitous).

The direct elasticity equation given previously was used to calculate what the coefficient for each scenario year should be in order to achieve an elasticity of 0.8 given that year's number of chargers and EV share. The results are shown in the table below:
|Scenario Year               |2022     |2035     |2050     |
|----------------------------|---------|---------|---------|
|Number of Chargers          |    7,716|   29,968|  143,410|
|Population                  |3,283,069|3,399,092|3,398,623|
|Chargers per Capita         |  0.00235|  0.00882|  0.04220|
|ln(1 + Chargers per Capita) |  0.00235|  0.00878|  0.04133|
|Calibrated No-Build EV Share|    3.74%|      25%|      45%|
|Desired Coefficient         |  354.031|  121.518|   35.193|

Conveniently (and possibly due to the exponential increase in the number of chargers), the desired coefficient decays exponentially over time, with the formula $354.347\times\exp{(-0.0825\times(\textnormal{Scenario Year}-2022))}$ almost perfectly matching the desired coefficients calculated in the previous table. It was decided to test implementing an exponentially decreasing coefficient.

The initial thinking was to use the formula to update the coefficient in the scenario manager (which updates several year-specific values). However, an equation that simplifies the implementation follows from the associative property multiplication:

$(\textnormal{Base Year Coefficient}\times\textnormal{Temporal Decay})\times\textnormal{Utility Expression}=\textnormal{Base Year Coefficient}\times(\textnormal{Temporal Decay}\times\textnormal{Utility Expression})$

From this, we can have the base year coefficient be in the coefficient file and just move the temporal decay into the utility expression in the spec file. The scenario year is already in the vehicle type choice constants, and the decay factor (added as `chargerSensitivityDecayFactor`) can simply be added to those as well. This results in the sensitivity to the number of chargers being lower for future years without updating any values in the scenario manager.

The great reduction in the coefficient value meant that the EV shares needed to be recalibrated so that the no-build shares match the targets set by planners. This was done easily, and the resulting calibration coefficients all have a magnitude of less than 1.5, as opposed to having a value of -12 for 2035 and -68 for 2050. This implementation was then tested, first by running just the resident model with 1000 households to identify any spelling errors, etc., and then with two full model runs: One replicating a recent 2035 no-build run and another replicating a recent 2035 build run, but with the new coefficients in place. The results (see above) were more consistent with the desired elasticity of 0.8, especially when factoring in that the build run had an EV rebate policy that should also increase EV ownership rates.

While this approach isn't perfect, it is a clear improvement over the previous one. If in the future it is decided that an elasticity other than 0.8 is deemed to be more appropriate, the procedure can easily be done again to calculate new values for the base year coefficient and the decay factor. Further, if the decay factor were to be given a more negative value, then that would result in the elasticity decreasing over time as @jfdman had suggested.