### PR TITLE
Add micromobility access to travel time reporter

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -411,8 +411,8 @@ class TravelTimeReporter:
             ["i", "j"]
         )
 
-        _ebikeMaxTime = self.constants["ebikeMaxDistance"] / self.constants["ebikeSpped"] * 60
-        _escooterMaxTime = self.constants["escooterMaxDistance"] / self.constants["escooterSpped"] * 60
+        _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
+        _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60
 
         _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]
         _escooterTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -414,8 +414,8 @@ class TravelTimeReporter:
         _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
         _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60
 
-        _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]
-        _escooterTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]
+        _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microRentTime"]
+        _escooterTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microRentTime"]
 
         self.results["ebike"] = np.where(
             _ebikeTime > _ebikeMaxTime,

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -410,15 +410,23 @@ class TravelTimeReporter:
         ).reset_index().fillna(self.settings["infinity"]).sort_values(
             ["i", "j"]
         )
+
+        _ebikeMaxTime = self.constants["ebikeMaxDistance"] / self.constants["ebikeSpped"] * 60
+        _escooterMaxTime = self.constants["escooterMaxDistance"] / self.constants["escooterSpped"] * 60
+
+        _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]
+        _escooterTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microConstant"] + self.constants["microRentTime"]
+
         self.results["ebike"] = np.where(
-            self.results["bike"] == self.settings["infinity"],
+            _ebikeTime > _ebikeMaxTime,
             self.settings["infinity"],
-            self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"]
+            _ebikeTime
         )
+
         self.results["escooter"] = np.where(
-            self.results["bike"] == self.settings["infinity"],
+            _escooterTime > _escooterMaxTime,
             self.settings["infinity"],
-            self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"]
+            _escooterTime
         )
 
     def write_results(self):


### PR DESCRIPTION
## Proposed changes

The travel time reporter previously did not factor in the access or rent times for micromobility and didn't cap the distances at the maximum value. This pull request fixes that.

## Impact

The travel times by ebike and escooter should increase and more OD-pairs will have values of 999.

## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Travel time reporter was run through Emme on Triton and successfully produced output files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings