### PR TITLE
Include all transit modes in travel time reporter

### DIFF
--- a/src/main/python/AMTravelTimeReporterConfigs.yaml
+++ b/src/main/python/AMTravelTimeReporterConfigs.yaml
@@ -4,6 +4,14 @@ infinity: 999
 outfile: report\walkMgrasWithin45Min_AM.csv
 
 transit_skim_matrices: # If set to True, replace values of zero with the number set as infinity
+  WALK_LOC_FIRSTWAIT__{}: False
+  WALK_LOC_XFERWALK__{}: False
+  WALK_LOC_XFERWAIT__{}: False
+  WALK_LOC_TOTALIVTT__{}: True
+  WALK_PRM_FIRSTWAIT__{}: False
+  WALK_PRM_XFERWALK__{}: False
+  WALK_PRM_XFERWAIT__{}: False
+  WALK_PRM_TOTALIVTT__{}: True
   WALK_MIX_FIRSTWAIT__{}: False
   WALK_MIX_XFERWALK__{}: False
   WALK_MIX_XFERWAIT__{}: False

--- a/src/main/python/MDTravelTimeReporterConfigs.yaml
+++ b/src/main/python/MDTravelTimeReporterConfigs.yaml
@@ -4,6 +4,14 @@ infinity: 999
 outfile: report\walkMgrasWithin45Min_MD.csv
 
 transit_skim_matrices: # If set to True, replace values of zero with the number set as infinity
+  WALK_LOC_FIRSTWAIT__{}: False
+  WALK_LOC_XFERWALK__{}: False
+  WALK_LOC_XFERWAIT__{}: False
+  WALK_LOC_TOTALIVTT__{}: True
+  WALK_PRM_FIRSTWAIT__{}: False
+  WALK_PRM_XFERWALK__{}: False
+  WALK_PRM_XFERWAIT__{}: False
+  WALK_PRM_TOTALIVTT__{}: True
   WALK_MIX_FIRSTWAIT__{}: False
   WALK_MIX_XFERWALK__{}: False
   WALK_MIX_XFERWAIT__{}: False

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -319,31 +319,33 @@ class TravelTimeReporter:
         """
         print("Calculating transit times")
 
-        _loc_time = self.expand_skim(
+        _loc_time = (
             self.skims["WALK_LOC_FIRSTWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_LOC_XFERWALK__" + self.settings["time_period"]] +
             self.skims["WALK_LOC_XFERWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_LOC_TOTALIVTT__" + self.settings["time_period"]]
         )
 
-        _prm_time = self.expand_skim(
+        _prm_time = (
             self.skims["WALK_PRM_FIRSTWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_PRM_XFERWALK__" + self.settings["time_period"]] +
             self.skims["WALK_PRM_XFERWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_PRM_TOTALIVTT__" + self.settings["time_period"]]
         )
 
-        _mix_time = self.expand_skim(
+        _mix_time = (
             self.skims["WALK_MIX_FIRSTWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_XFERWALK__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_XFERWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_TOTALIVTT__" + self.settings["time_period"]]
         )
 
-        self.skims["transit_time"] = np.minimum(
-            _loc_time,
-            _prm_time,
-            _mix_time
+        self.skims["transit_time"] = self.expand_skim(
+                np.minimum(
+                _loc_time,
+                _prm_time,
+                _mix_time
+            )
         )
 
     def get_total_transit_time(self):

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -318,11 +318,32 @@ class TravelTimeReporter:
         Obtains the total transit time, not including access or egress
         """
         print("Calculating transit times")
-        self.skims["transit_time"] = self.expand_skim(
+
+        _loc_time = self.expand_skim(
+            self.skims["WALK_LOC_FIRSTWAIT__" + self.settings["time_period"]] +
+            self.skims["WALK_LOC_XFERWALK__" + self.settings["time_period"]] +
+            self.skims["WALK_LOC_XFERWAIT__" + self.settings["time_period"]] +
+            self.skims["WALK_LOC_TOTALIVTT__" + self.settings["time_period"]]
+        )
+
+        _prm_time = self.expand_skim(
+            self.skims["WALK_PRM_FIRSTWAIT__" + self.settings["time_period"]] +
+            self.skims["WALK_PRM_XFERWALK__" + self.settings["time_period"]] +
+            self.skims["WALK_PRM_XFERWAIT__" + self.settings["time_period"]] +
+            self.skims["WALK_PRM_TOTALIVTT__" + self.settings["time_period"]]
+        )
+
+        _mix_time = self.expand_skim(
             self.skims["WALK_MIX_FIRSTWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_XFERWALK__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_XFERWAIT__" + self.settings["time_period"]] +
             self.skims["WALK_MIX_TOTALIVTT__" + self.settings["time_period"]]
+        )
+
+        self.skims["transit_time"] = np.minimum(
+            _loc_time,
+            _prm_time,
+            _mix_time
         )
 
     def get_total_transit_time(self):


### PR DESCRIPTION
## Proposed changes

This pull request edits the travel time reporter script to factor in all transit modes, not just those with mixed paths. It looks up the local, premium, and mixed skims and takes the minimum.

## Impact

More OD-pairs (that are only available via local or premium routes) should be factored into the transit time reporting.

## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] The data exporter step was run from Emme and did not crash.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
