### PR TITLE
Drop fields from hwytcad

### DIFF
--- a/src/main/emme/toolbox/export/export_data_loader_network.py
+++ b/src/main/emme/toolbox/export/export_data_loader_network.py
@@ -176,35 +176,12 @@ Export network results to csv files for SQL data loader."""
             ("Length", "length"),
             ("Dir", "is_one_way"),
             ("hwycov-id:1", "@tcov_id"),
-            ("ID:1", "@tcov_id"),
-            ("Length:1", "length_feet"),
-            ("QID", "zero"),
-            ("CCSTYLE", "zero"),
-            ("UVOL", "zero"),
-            ("AVOL", "zero"),
-            ("TMP1", "zero"),
-            ("TMP2", "zero"),
-            ("PLOT", "zero"),
             ("SPHERE", "@sphere"),
-            ("RTNO", "zero"),
-            ("LKNO", "zero"),
             ("NM", "#name"),
             ("FXNM", "#name_from"),
             ("TXNM", "#name_to"),
             ("AN", "i"),
             ("BN", "j"),
-            ("COJUR", "zero"),
-            ("COSTAT", "zero"),
-            ("COLOC", "zero"),
-            ("RLOOP", "zero"),
-            ("ADTLK", "zero"),
-            ("ADTVL", "zero"),
-            ("PKPCT", "zero"),
-            ("TRPCT", "zero"),
-            ("SECNO", "zero"),
-            ("DIR:1", "zero"),
-            ("FFC", "type"),
-            ("CLASS", "zero"),
             ("ASPD", "@speed_adjusted"),
             ("YR", "@year_open_traffic"),
             ("PROJ", "@project_code"),
@@ -216,37 +193,18 @@ Export network results to csv files for SQL data loader."""
             ("PMTRUCK", "@truck_pm"),
             ("EVTRUCK", "@truck_ev"),
             ("SPD", "@speed_posted"),
-            ("TSPD", "zero"),
             ("WAY", "way"),
             ("MED", "@median"),
             ("COST", "@cost_operating"),
         ]
         directional_attrs = [
-            ("ABLNO", "@lane_md", "0"),
-            ("ABLNA", "@lane_am", "0"),
-            ("ABLNP", "@lane_pm", "0"),
             ("ABAU", "@lane_auxiliary", "0"),
-            ("ABPCT", "zero", "0"),
-            ("ABPHF", "zero", "0"),
             ("ABCNT", "@traffic_control", "0"),
             ("ABTL", "@turn_thru", "0"),
             ("ABRL", "@turn_right", "0"),
             ("ABLL", "@turn_left", "0"),
-            ("ABTLB", "zero", "0"),
-            ("ABRLB", "zero", "0"),
-            ("ABLLB", "zero", "0"),
             ("ABGC", "@green_to_cycle_init", "0"),
             ("ABPLC", "per_lane_capacity", "1900"),
-            ("ABTMO", "@time_link_md", "999"),
-            ("ABTMA", "@time_link_am", "999"),
-            ("ABTMP", "@time_link_pm", "999"),
-            ("ABTXO", "@time_inter_md", "0"),
-            ("ABTXA", "@time_inter_am", "0"),
-            ("ABTXP", "@time_inter_pm", "0"),
-            ("ABCST", "zero", "999.999"),
-            ("ABVLA", "zero", "0"),
-            ("ABVLP", "zero", "0"),
-            ("ABLOS", "zero", "0"),
         ]
         for key, name, default in directional_attrs:
             hwylink_attrs.append((key, name))
@@ -270,7 +228,6 @@ Export network results to csv files for SQL data loader."""
             ("ABH2CST",   "hov2_total_gencost", ""),
             ("ABH3CST",   "hov3_total_gencost", ""),
             ("ABSTM",     "auto_time", ""),
-            ("ABHTM",     "auto_time", ""),
         ]
         periods = ["_ea", "_am", "_md", "_pm", "_ev"]
         for column in time_period_atts:
@@ -305,14 +262,6 @@ Export network results to csv files for SQL data loader."""
             hwylink_attrs.append((key, name))
             if key.startswith("AB"):
                 hwylink_attrs.append(("BA" + key[2:], (name, default)))
-        for period in periods:
-            for key, name, default in vdf_attrs:
-                name = name + period if name.startswith("@") else name
-                default = default or "0"
-                hwylink_attrs.append((key + period.upper(), name))
-                if key.startswith("AB"):
-                    hwylink_attrs.append(("BA" + key[2:] + period.upper(), (name, default)))
-
         network = base_scenario.get_partial_network(["LINK"], include_attributes=True)
 
         #copy assignment from period scenarios

--- a/src/main/python/hwyShapeExport.py
+++ b/src/main/python/hwyShapeExport.py
@@ -28,9 +28,6 @@ def export_highway_shape(scenario_path: str) -> geopandas.GeoDataFrame:
                            usecols=["ID",  # highway coverage id
                                     "NM",  # link name
                                     "Length",  # link length in miles
-                                    "COJUR",  # count jurisdiction code
-                                    "COSTAT",  # count station number
-                                    "COLOC",  # count location code
                                     "FC",  # initial functional class
                                     "HOV",  # link operation type
                                     "EATRUCK",  # truck restriction code - Early AM
@@ -387,9 +384,6 @@ def export_highway_shape(scenario_path: str) -> geopandas.GeoDataFrame:
     hwy_tcad = hwy_tcad[["ID",
                          "NM",
                          "Length",
-                         "COJUR",
-                         "COSTAT",
-                         "COLOC",
                          "FC",
                          "FC_Desc",
                          "HOV",
@@ -488,9 +482,6 @@ def export_highway_shape(scenario_path: str) -> geopandas.GeoDataFrame:
     hwy_tcad.rename(columns={"ID": "hwycov_id",
                              "NM": "link_name",
                              "Length": "len_mile",
-                             "COJUR": "count_jur",
-                             "COSTAT": "count_stat",
-                             "COLOC": "count_loc",
                              "FC": "fc",
                              "FC_Desc": "fc_desc",
                              "HOV": "hov",


### PR DESCRIPTION
### **Drop attributes from report/hwyTcad.csv**

## Proposed changes

This change trims down the width of the report/hwyTcad.csv file by dropping 121 columns (goes from 307 to 186 columns) that were identified to be irrelevant for reporting purposes, redundant, or simply not useful to report. 

## Impact

The report/hwyTcad.csv file gets uploaded to our datalake system and will make the file easier to work with along with reducing clutter by making the table slimmer. 

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] The modified scripts were incorporated into 2 (two) different runs and the data exporter and datalake upload steps were ran for both. 
- [x] After the above completed successfully, ran the validation script, visualizer script, and generated their corresponding PBI reports to ensure it did not cause issues with either. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

For a complete list of attributes that were dropped, please refer to the following file: [hwy_tcad_columns.xlsx](https://sandag.sharepoint.com/:x:/r/sites/SANDAGModels/_layouts/15/Doc.aspx?sourcedoc=%7B04060CE2-5161-4790-BF16-E000DDF5BA15%7D&file=hwy_tcad_columns.xlsx&action=default&mobileredirect=true)
