### PR TITLE
Increase maxWalkIfMTAccessAvailable from a half mile to a mile

### DIFF
--- a/docs/application/flexible-fleets.md
+++ b/docs/application/flexible-fleets.md
@@ -33,7 +33,7 @@ Several new attributes were added to allow the user to configure how flexible fl
 | DiversionFactor            | Time multiplier accounting for diversion to service other passengers                                                                         | 1.25 for both   |
 | StartPeriod                | Time period to start service (not yet implemented)                                                                                           | 9 for both      |
 | EndPeriod                  | Time period to end service (not yet implemented)                                                                                             | MT: 32, NEV: 38 |
-| maxWalkIfMTAccessAvailable | Maximum disatance someone is willing to walk at the destination end if flexible fleet services are available (same for microtransit and NEV) | 0.5             |
+| maxWalkIfMTAccessAvailable | Maximum disatance someone is willing to walk at the destination end if flexible fleet services are available (same for microtransit and NEV) | 1.0             |
 
 ## Travel Time Calculation
 ### Direct Time

--- a/src/asim/configs/common/constants.yaml
+++ b/src/asim/configs/common/constants.yaml
@@ -270,7 +270,7 @@ nevDiversionConstant: 6
 nevDiversionFactor: 1.25
 nevStartPeriod: 9
 nevEndPeriod: 38
-maxWalkIfMTAccessAvailable: 0.5 # Maximum distance to walk to premium transit if microtransit access is available
+maxWalkIfMTAccessAvailable: 1.0 # Maximum distance to walk to premium transit if microtransit access is available
 
 # cost of "average" monthly transit pass cost.  Used in transit pass ownership model.
 # cost of pass divided by 2 for age < 18 and 65+.


### PR DESCRIPTION
## Proposed changes

The value of `maxWalkIfMTAccessAvailable` in configs\common\constants.yaml to be raised from a half mile to a mile. This would mean that if a flexible fleet service is available to take someone from a transit stop to their tour destination, they will assumed to walk if the destination is less than a mile from the transit station as opposed to a half mile.

## Impact

A sensitivity test found that there was little change in direct flexible fleet trips. However, access and egress to fixed route transit (on the attraction end) decreased significantly.
![image](https://github.com/user-attachments/assets/3ccc9dd3-5d92-4f79-ac2d-2fce510c19d4)
![image](https://github.com/user-attachments/assets/949d7f0b-09e1-4094-b724-6fc4b3ea0447)


## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] An ABM3 run with scenario ID 195 was done with this value.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
