### PR TITLE
Fix max distance calculation in TravelTimeReporter.py

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -373,7 +373,7 @@ class TravelTimeReporter:
         
         # Create Boolean matrix that is True if the flexible fleets service is available for the OD pair and False if it is not
         available = pd.DataFrame(
-            (orig_service > 0) & (orig_service == dest_service) & (self.skims["HOV3_M_TIME__" + self.settings["time_period"]] < self.constants[flavor + "MaxDist"]),
+            (orig_service > 0) & (orig_service == dest_service) & (self.skims["HOV3_M_DIST__" + self.settings["time_period"]] < self.constants[flavor + "MaxDist"]),
             self.land_use.index,
             self.land_use.index
         )


### PR DESCRIPTION
## Proposed changes

Travel time reporter was comparing skimmed drive time to maximum distance for flexible fleet, corrected this to use skimmed distance. Already correct in model.

## Impact

Fix flexible fleet access numbers in performance metrics

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Untested, don't anticipate any issues (one word change)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
