### PR TITLE
Automatically update release version in GUI and properties

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -1301,6 +1301,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
             ,"environment" : prod_env
             ,"network_path" : props["network"]
             ,"landuse_path" : props["landuse"]
+            ,"release_path" : props["release"]
         }
         _m.logbook_write("Created new scenario_guid: %s" % (datalake_metadata_dict['scenario_guid']))
         got_id, scenario_id = self.get_scenario_id(datalake_metadata_dict['scenario_guid'], scenario_title, prod_env)

--- a/src/main/python/datalake_exporter.py
+++ b/src/main/python/datalake_exporter.py
@@ -115,7 +115,8 @@ def create_scenario_df(ts, EMME_metadata, parent_dir_name, output_path):
         "select_link" : [EMME_metadata["select_link"]],
         "sample_rate" : [EMME_metadata["sample_rate"]],
         "network_path" : [EMME_metadata["network_path"]],
-        "landuse_path" : [EMME_metadata["landuse_path"]]
+        "landuse_path" : [EMME_metadata["landuse_path"]],
+        "release_path" : [EMME_metadata["release_path"]]
     }
 
     meta_df = pd.DataFrame(metadata)

--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -68,8 +68,10 @@ class CreateScenarioGUI(tkinter.Frame):
             divider=u"_"*200
             if getattr(sys, 'frozen', False):
                 self.releaseDir=os.path.abspath(os.path.join(os.path.dirname(sys.executable), '..', '..'))
+                self.version=os.path.basename(os.path.abspath(os.path.join(os.path.dirname(sys.executable), '..')))
             else:
                 self.releaseDir=os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+                self.version=os.path.basename(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
             self.defaultScenarioDir="T:\\STORAGE-63T\\2025RP_init_concept\\"
             self.defaultNetworkDir="T:\\projects\\sr15\\tned_etl\\2025RP_draft"
             self.defaultLandUseDir="T:\\projects\\sr15\\land_use\\2025RP_draft"
@@ -80,7 +82,11 @@ class CreateScenarioGUI(tkinter.Frame):
             self.buttonVar= tkinter.IntVar(root)
             self.yButton=tkinter.Radiobutton(body, text="Yes", variable=self.buttonVar, value=1, command=self.initStudy)
             self.nButton=tkinter.Radiobutton(body, text="No", variable=self.buttonVar, value=0,command=self.initStudy)
-            tkinter.Label(body, text=u"Release Version 15.2.0\n"+divider, font=("Helvetica", 11, 'bold'), width=50, fg='royal blue').grid(row=current_row,columnspan=5)
+            if self.version[:8] == "version_":
+                version_name = self.version[8:].replace("_",".",2)
+            else:
+                version_name = self.version
+            tkinter.Label(body, text=u"Release Version " + version_name + "\n"+divider, font=("Helvetica", 11, 'bold'), width=50, fg='royal blue').grid(row=current_row,columnspan=5)
             current_row += 1
             tkinter.Label(body, text=u"Create an ABM Work Space", font=("Helvetica", 10, 'bold')).grid(row=current_row,columnspan=n_columns)
             current_row += 1
@@ -123,17 +129,6 @@ class CreateScenarioGUI(tkinter.Frame):
             current_row += 1
             tkinter.Label(body, text=u"Create an ABM scenario", font=("Helvetica", 10, 'bold')).grid(row=current_row,columnspan=n_columns)
             current_row += 1
-
-            #tkinter.Label(body, text=u"Version", font=("Helvetica", 8, 'bold')).grid(row=8)
-            #var = StringVar(root)
-            if getattr(sys, 'frozen', False):
-                self.version=os.path.basename(os.path.abspath(os.path.join(os.path.dirname(sys.executable), '..')))
-            else:
-                self.version=os.path.basename(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
-            #optionList=["version_14_2_2"]
-            #option=tkinter.OptionMenu(body,var,*optionList,command=self.setversion)
-            #option.config(width=50)
-            #option.grid(row=8, column=1)
 
             tkinter.Label(body, text=u"Emme Version", font=("Helvetica", 8, 'bold')).grid(row=current_row)
             var = tkinter.StringVar(root)
@@ -377,6 +372,7 @@ class CreateScenarioGUI(tkinter.Frame):
                 self.update_property("geographyID = 1", "geographyID = " + self.geo.get())
                 self.update_property("network = NETWORK", "network = " + self.networkpath.get())
                 self.update_property("landuse = LANDUSE", "landuse = " + self.lupath.get())
+                self.update_property("release = RELEASE", "release = " + self.releaseDir+"\\"+self.version)
             elif type=="study":
                 studyyears = self.studyyears.get().split(',')
                 exclude_file = self.studynetworkpath.get() + '\\exclude.txt'

--- a/src/main/resources/sandag_abm.properties
+++ b/src/main/resources/sandag_abm.properties
@@ -1,6 +1,6 @@
 ##SANDAG ABM Properties
 ##Software Version
-version = version_15_0_0
+release = RELEASE
 landuse = LANDUSE
 network = NETWORK
 ## geography ID


### PR DESCRIPTION
## Proposed changes

Automatically update the release version and path in the GUI, sandag_abm.properties, and scenario table.

## Impact

Removes need to manually update version number in these places

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Created new release folder, created scenario, and wrote to datalake. Confirmed version number was accurate in GUI, properties file, and scenario table in datalake.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
