### PR TITLE
Removed flexible fleet wait time from travel time reporter

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -393,7 +393,7 @@ class TravelTimeReporter:
                     self.constants[flavor + "DiversionConstant"] + direct_time,
                     self.constants[flavor + "DiversionFactor"] * direct_time
                 )
-                self.settings["infinity"]
+                self.settings["infinity"],
             ),
             self.land_use.index,
             self.land_use.index

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -392,8 +392,8 @@ class TravelTimeReporter:
                 np.maximum(
                     self.constants[flavor + "DiversionConstant"] + direct_time,
                     self.constants[flavor + "DiversionFactor"] * direct_time
-                )
-                self.settings["infinity"],
+                ),
+                self.settings["infinity"]
             ),
             self.land_use.index,
             self.land_use.index

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -392,7 +392,7 @@ class TravelTimeReporter:
                 np.maximum(
                     self.constants[flavor + "DiversionConstant"] + direct_time,
                     self.constants[flavor + "DiversionFactor"] * direct_time
-                ) + self.constants[flavor + "WaitTime"],
+                )
                 self.settings["infinity"]
             ),
             self.land_use.index,


### PR DESCRIPTION
## Proposed changes

This removes the initial wait time for flexible fleets from the travel time reporter.

## Impact

More destinations will be available within a trip of a specified time by microtransit or NEV.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

No tests were run

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
