### PR TITLE
Link Transit Travel Times

### DIFF
--- a/src/main/emme/toolbox/assignment/build_transit_scenario.py
+++ b/src/main/emme/toolbox/assignment/build_transit_scenario.py
@@ -330,13 +330,15 @@ class BuildTransitNetwork(_m.Tool(), gen_utils.Snapshot):
             # (The auto_time attribute is generated from the VDF values which include reliability factor)
             ## also copying auto_time to ul1, so it does not get wiped when transit connectors are created. 
             
-            src_attrs = [params["fixed_link_time"]]
-            dst_attrs = ["data2"]
-            if scenario.has_traffic_results and "@auto_time" in scenario.attributes("LINK"):
-                src_attrs.extend(["@auto_time", "@auto_time"])
-                dst_attrs.extend(["auto_time", "data1"])
-            values = network.get_attribute_values("LINK", src_attrs)
-            network.set_attribute_values("LINK", dst_attrs, values)
+            for link in network.links():
+                if scenario.has_traffic_results and "@auto_time" in scenario.attributes("LINK"):
+                    link["auto_time"]=link["@auto_time"]
+                    link["data1"]=link["@auto_time"]
+                rail_modes = set(network.mode(m) for m in "lco")
+                if link.modes & rail_modes:
+                    link["data2"]=link[params["fixed_rail_link_time"]]
+                else:
+                    link["data2"]=link[params["fixed_bus_link_time"]]
 
             scenario.publish_network(network)
             self._node_id_tracker = None

--- a/src/main/emme/toolbox/assignment/transit_assignment.py
+++ b/src/main/emme/toolbox/assignment/transit_assignment.py
@@ -267,7 +267,8 @@ class TransitAssignment(_m.Tool(), gen_utils.Snapshot):
                 "xfer_headway": "@headway_ea",
                 "fare": "@fare_per_op",
                 "in_vehicle": "@vehicle_per_op",
-                "fixed_link_time": "@trtime"
+                "fixed_rail_link_time": "@trtime",
+                "fixed_bus_link_time": "@time_link_ea"
             },
             "AM": {
                 "access" : access,
@@ -280,7 +281,8 @@ class TransitAssignment(_m.Tool(), gen_utils.Snapshot):
                 "xfer_headway": "@headway_am",
                 "fare": "@fare_per_pk",
                 "in_vehicle": "@vehicle_per_pk",
-                "fixed_link_time": "@trtime"
+                "fixed_rail_link_time": "@trtime",
+                "fixed_bus_link_time": "@time_link_am"
             },
             "MD": {
                 "access" : access,
@@ -293,7 +295,8 @@ class TransitAssignment(_m.Tool(), gen_utils.Snapshot):
                 "xfer_headway": "@headway_md",
                 "fare": "@fare_per_op",
                 "in_vehicle": "@vehicle_per_op",
-                "fixed_link_time": "@trtime"
+                "fixed_rail_link_time": "@trtime",
+                "fixed_bus_link_time": "@time_link_md"
             },
             "PM": {
                 "access" : access,
@@ -306,7 +309,8 @@ class TransitAssignment(_m.Tool(), gen_utils.Snapshot):
                 "xfer_headway": "@headway_pm",
                 "fare": "@fare_per_pk",
                 "in_vehicle": "@vehicle_per_pk",
-                "fixed_link_time": "@trtime"
+                "fixed_rail_link_time": "@trtime",
+                "fixed_bus_link_time": "@time_link_pm"
             },
             "EV": {
                 "access" : access,
@@ -319,7 +323,8 @@ class TransitAssignment(_m.Tool(), gen_utils.Snapshot):
                 "xfer_headway": "@headway_ev",
                 "fare": "@fare_per_op",
                 "in_vehicle": "@vehicle_per_op",
-                "fixed_link_time": "@trtime"
+                "fixed_rail_link_time": "@trtime",
+                "fixed_bus_link_time": "@time_link_ev"
             }
         }
         return perception_parameters[period]

--- a/src/main/emme/toolbox/export/export_data_loader_network.py
+++ b/src/main/emme/toolbox/export/export_data_loader_network.py
@@ -988,6 +988,7 @@ Export network results to csv files for SQL data loader."""
                     next_seg = seg2.line.segment(seg2.number+1)
                     for attr in segment_alights:
                         next_seg[attr] += seg2[attr]
+                    attr_map["transit_time"] = seg1["transit_time"] + seg2["transit_time"]
                 network.merge_links(node, mapping)
 
         # Backup transit lines with altered routes and remove from network


### PR DESCRIPTION
## Proposed changes

This pull request makes 2 (two) changes related to link transit travel times:

1. It assigns link transit travel times based on whether the link is a rail link or a bus-only street
2. For links that are split due to timed transfer virtual segments, this change sums up the link transit travel time between the 2 (two) newly created splits

## Impact

The changes in this pull request:

1. Will redistribute ridership between different transit modes. In particular, rail-based routes will experience an increase in ridership, while street-based routes will experience a decrease due to bus-only streets having been unaccounted for travel times which resulted in lower travel times and hence higher utility and ridership.
2. Will eliminate negative and 0 (zero) reported values for BASEIVTT under report/transit_flow.csv. For a route segment between 2 (two) transit stops, the BASEIVTT value is the summation of the link travel times minus the dwell time. Values less than or equal to 0 (zero) were being caused by the omission of bus-only street link travel times. Simultaneously, when links were split due to the introduction of timed transfer virtual segments (by Emme), the 2 (two) resulting split links' travel times were not being summed up and only 1 (one) was being reported and hence resulted in very short travel times. 

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] The changes were incorporated into a few different previously-ran scenarios and changes were compared before and after the fix. Manual calculations were compared to the Emme calculations to verify. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

None
