### PR TITLE
Remove rename in travel time reporter

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -114,11 +114,6 @@ class TravelTimeReporter:
                         "skims",
                         self.settings["active_skim_files"][skim_name]
                 )
-            ).rename(
-                columns = {
-                    "OMAZ": "i",
-                    "DMAZ": "j",
-                }
             ).set_index(
                 ["i", "j"]
             )


### PR DESCRIPTION
## Proposed changes

Removes line in travel time reporter that renames "OMAZ" and "DMAZ" columns in walk skims to "i" and "j". maz_maz_walk.csv now already contains "i" and "j" columns

## Impact

Fixes error in travel time reporter caused by duplicate columns after renaming

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran relevant line from command line without error

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings