### PR TITLE
Fix java unicode error

### DIFF
--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -347,11 +347,12 @@ class CreateScenarioGUI(tkinter.Frame):
 
         #Update properties file
         def update_property(self, old, new):
+            new_updated = new.replace(r'\U', r'/U').replace(r'\u', r'/u')
             property_file = os.path.join(self.scenariopath.get(), 'conf', 'sandag_abm.properties')
             property_file = property_file.replace('\\\\', '/')
             with open(property_file, 'r') as file :
                 filedata = file.read()
-            filedata = filedata.replace(old, new)
+            filedata = filedata.replace(old, new_updated)
             with open(property_file, 'w') as file:
                 file.write(filedata)
 


### PR DESCRIPTION
## Proposed changes

Java processes would crash if release, network, or land use folders were in the "user" folder, as it would interpret "\user" in the file path as a unicode escape sequence. This update automatically replaces "\u" with "/u" in these file paths in sandag_abm.properties to prevent this.

## Impact

Allows these folders to be in the user folder or other folders starting with "u"

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Created scenario with release, network, and land use folders in user folder, checked that sandag_abm.properties was updated correctly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
