### PR TITLE
Fix active skim columns in travel time reporter

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -107,14 +107,22 @@ class TravelTimeReporter:
         Reads active skims into memory as data frames
         """
         for skim_name in self.settings["active_skim_files"]:
-            self.skims[skim_name] = pd.read_csv(
-                        os.path.join(
-                        self.model_run,
-                        "output",
-                        "skims",
-                        self.settings["active_skim_files"][skim_name]
+            active_skims = pd.read_csv(
+                os.path.join(
+                    self.model_run,
+                    "output",
+                    "skims",
+                    self.settings["active_skim_files"][skim_name]
                 )
-            ).set_index(
+            )
+            if not "i" in active_skims.columns:
+                active_skims = active_skims.rename(
+                    columns = {
+                        "OMAZ": "i",
+                        "DMAZ": "j",
+                    }
+                )
+            self.skims[skim_name] = active_skims.set_index(
                 ["i", "j"]
             )
 


### PR DESCRIPTION
## Proposed changes

Travel time uses one function to read in both walk and bike skims. Walk skims now already contain "i", "j" columns, while bike skims do not. To fix this, check if skims contain "i" column and only rename if the column does not already exist.

## Impact

Fix crash in TravelTimeReporter

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Currently untested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
