### PR TITLE
Fix external zones not added to i,j columns in walk skims

### DIFF
--- a/src/asim/scripts/resident/resident_preprocessing.py
+++ b/src/asim/scripts/resident/resident_preprocessing.py
@@ -228,11 +228,15 @@ class Series15_Processor:
                 od_connections = skim_df.loc[skim_df[origin_col] == closest_maz].copy()
                 print(f"\t origins with this internal maz {len(od_connections)}")
                 od_connections[origin_col] = ext_maz
+                if "i" in skim_df.columns:
+                    od_connections["i"] = ext_maz
                 new_connections.append(od_connections)
 
                 if dest_col is not None:
                     do_connections = skim_df.loc[skim_df[dest_col] == closest_maz].copy()
                     do_connections[dest_col] = ext_maz
+                    if "j" in skim_df.columns:
+                        do_connections["j"] = ext_maz
                     print(f"\t destinations with this internal maz {len(do_connections)}")
                     new_connections.append(do_connections)
 

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -115,14 +115,14 @@ class TravelTimeReporter:
                     self.settings["active_skim_files"][skim_name]
                 )
             )
-            if not "i" in active_skims.columns:
-                active_skims = active_skims.rename(
-                    columns = {
-                        "OMAZ": "i",
-                        "DMAZ": "j",
-                    }
-                )
-            self.skims[skim_name] = active_skims.set_index(
+            if "i" in active_skims.columns:
+                active_skims = active_skims.drop(["i", "j"],axis=1)
+            self.skims[skim_name] = active_skims.rename(
+                columns = {
+                    "OMAZ": "i",
+                    "DMAZ": "j",
+                }
+            ).set_index(
                 ["i", "j"]
             )
 


### PR DESCRIPTION
## Proposed changes

When external zones are added to maz_maz_walk.csv, they were only added to OMAZ and DMAZ columns, not i and j columns. Updated to add external zones to these columns to avoid duplicate i and j values. Also updated travel time reporter to not use these i and j columns (not strictly necessary but better for consistency)

## Impact

Fixes error in travel time reporter

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Untested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
