### PR TITLE
Include TAZ skims for travel times by active modes in Travel Time Reporter

### DIFF
--- a/src/main/python/AMTravelTimeReporterConfigs.yaml
+++ b/src/main/python/AMTravelTimeReporterConfigs.yaml
@@ -1,7 +1,7 @@
 time_period: AM
-time_threshold: 45
+time_threshold: 30
 infinity: 999
-outfile: report\walkMgrasWithin45Min_AM.csv
+outfile: report\walkMgrasWithin30Min_AM.csv
 
 transit_skim_matrices: # If set to True, replace values of zero with the number set as infinity
   WALK_LOC_XFERWALK__{}: False

--- a/src/main/python/AMTravelTimeReporterConfigs.yaml
+++ b/src/main/python/AMTravelTimeReporterConfigs.yaml
@@ -20,5 +20,5 @@ traffic_skim_matrices: # If set to True, replace values of zero with the number 
   SOV_NT_L_TIME__{}: False
 
 active_skim_files:
-  walk_time: maz_maz_walk.csv
-  bike_time: maz_maz_bike.csv
+  maz_walk_time: maz_maz_walk.csv
+  maz_bike_time: maz_maz_bike.csv

--- a/src/main/python/MDTravelTimeReporterConfigs.yaml
+++ b/src/main/python/MDTravelTimeReporterConfigs.yaml
@@ -20,5 +20,5 @@ traffic_skim_matrices: # If set to True, replace values of zero with the number 
   SOV_NT_L_TIME__{}: False
 
 active_skim_files:
-  walk_time: maz_maz_walk.csv
-  bike_time: maz_maz_bike.csv
+  maz_walk_time: maz_maz_walk.csv
+  maz_bike_time: maz_maz_bike.csv

--- a/src/main/python/MDTravelTimeReporterConfigs.yaml
+++ b/src/main/python/MDTravelTimeReporterConfigs.yaml
@@ -1,7 +1,7 @@
 time_period: MD
-time_threshold: 45
+time_threshold: 30
 infinity: 999
-outfile: report\walkMgrasWithin45Min_MD.csv
+outfile: report\walkMgrasWithin30Min_MD.csv
 
 transit_skim_matrices: # If set to True, replace values of zero with the number set as infinity
   WALK_LOC_XFERWALK__{}: False

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -161,8 +161,10 @@ class TravelTimeReporter:
 
         self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
         self.skims["walk_time"] = self.skims["taz_walk_time"].copy()
-        self.skims["bike_time"].loc[self.skims["maz_bike_time"].index] = self.skims["maz_bike_time"]
-        self.skims["walk_time"].loc[self.skims["maz_walk_time"].index] = self.skims["maz_walk_time"]
+        for ix, row in self.skims["maz_bike_time"].iterrows():
+            self.skims["bike_time"].loc[ix, "time"] = self.skims["maz_bike_time"].loc[ix, "time"]
+        for ix, row in self.skims["maz_walk_time"].iterrows():
+            self.skims["walk_time"].loc[ix, "time"] = self.skims["maz_walk_time"].loc[ix, "time"]
 
     def init_land_use(self):
         """

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -301,47 +301,31 @@ class TravelTimeReporter:
         """
         Returns transit access and egress times from every MGRA to every other MGRA
         """
-        print("Calculating direct flexible fleet access and egress times")
-        microtransit_direct_access_time = self.get_microtransit_direct_accegr_time(access = True, nev = False)
-        microtransit_direct_egress_time = self.get_microtransit_direct_accegr_time(access = False, nev = False)
-        nev_direct_access_time = self.get_microtransit_direct_accegr_time(access = True, nev = True)
-        nev_direct_egress_time = self.get_microtransit_direct_accegr_time(access = False, nev = True)
+        # print("Calculating direct flexible fleet access and egress times")
+        # microtransit_direct_access_time = self.get_microtransit_direct_accegr_time(access = True, nev = False)
+        # microtransit_direct_egress_time = self.get_microtransit_direct_accegr_time(access = False, nev = False)
+        # nev_direct_access_time = self.get_microtransit_direct_accegr_time(access = True, nev = True)
+        # nev_direct_egress_time = self.get_microtransit_direct_accegr_time(access = False, nev = True)
 
-        print("Calculating flexible fleet diverted access and egress times")
-        microtransit_access_time = self.get_total_microtransit_accegr_times(microtransit_direct_access_time, nev = False)
-        microtransit_egress_time = self.get_total_microtransit_accegr_times(microtransit_direct_egress_time, nev = False)
-        nev_access_time = self.get_total_microtransit_accegr_times(nev_direct_access_time, nev = True)
-        nev_egress_time = self.get_total_microtransit_accegr_times(nev_direct_egress_time, nev = True)
+        # print("Calculating flexible fleet diverted access and egress times")
+        # microtransit_access_time = self.get_total_microtransit_accegr_times(microtransit_direct_access_time, nev = False)
+        # microtransit_egress_time = self.get_total_microtransit_accegr_times(microtransit_direct_egress_time, nev = False)
+        # nev_access_time = self.get_total_microtransit_accegr_times(nev_direct_access_time, nev = True)
+        # nev_egress_time = self.get_total_microtransit_accegr_times(nev_direct_egress_time, nev = True)
 
-        print("Getting flexible fleet availability")
-        microtransit_access_available = self.field2matrix("microtransit_access_available", origin = True)
-        microtransit_egress_available = self.field2matrix("microtransit_egress_available", origin = False)
-        nev_access_available = self.field2matrix("nev_access_available", origin = True)
-        nev_egress_available = self.field2matrix("nev_egress_available", origin = False)
+        # print("Getting flexible fleet availability")
+        # microtransit_access_available = self.field2matrix("microtransit_access_available", origin = True)
+        # microtransit_egress_available = self.field2matrix("microtransit_egress_available", origin = False)
+        # nev_access_available = self.field2matrix("nev_access_available", origin = True)
+        # nev_egress_available = self.field2matrix("nev_egress_available", origin = False)
 
         print("Getting walk access and egress times")
         walk_access_time = self.field2matrix("walk_accegr_time", origin = True)
         walk_egress_time = self.field2matrix("walk_accegr_time", origin = False)
 
         print("Calculating access and egress times")
-        self.skims["access_time"] = np.where(
-            nev_access_available,
-            nev_access_time,
-            np.where(
-                microtransit_access_available,
-                microtransit_access_time,
-                walk_access_time
-            )
-        )
-        self.skims["egress_time"] = np.where(
-            nev_egress_available,
-            nev_egress_time,
-            np.where(
-                microtransit_egress_available,
-                microtransit_egress_time,
-                walk_egress_time
-            )
-        )
+        self.skims["access_time"] = walk_access_time
+        self.skims["egress_time"] = walk_egress_time
 
     def get_transit_time(self):
         """
@@ -460,6 +444,8 @@ class TravelTimeReporter:
             self.results["taz_time"],
             self.results[mode]
         )
+
+        del self.results["taz_time"]
 
     # # # # # # # # # # # # OUTPUT FUNCTIONS # # # # # # # # # # # #
     #==============================================================#

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -141,7 +141,7 @@ class TravelTimeReporter:
             "walkTime": "taz_walk_time"
         }
         for core in active_taz_skims:
-            skim_values = np.array(skims[core.format(self.settings["time_period"])])
+            skim_values = np.array(skims[core])
             skim_values = np.where(
                 skim_values == 0,
                 self.settings["infinity"],

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -251,13 +251,11 @@ class TravelTimeReporter:
             id_vars = ["i"],
             var_name = "j",
             value_name = "time"
-        ).query(
-            "time <= @time_threshold"
-            ).sort_values(
-                ["i", "j"]
+        ).sort_values(
+            ["i", "j"]
             ).set_index(
                 ["i", "j"]
-            )["time"]
+                )["time"]
 
     # # # # # # # # # # # # CALCULATOR FUNCTIONS # # # # # # # # # # # #
     #==================================================================#
@@ -454,9 +452,11 @@ class TravelTimeReporter:
                 "nev": self.unpivot_skim("nev_time"),
 #                "drive_alone": self.unpivot_skim("drive_alone_time")
             }
-        ).reset_index().fillna(self.settings["infinity"]).sort_values(
+        ).query(
+            "time <= @time_threshold"
+            ).reset_index().fillna(self.settings["infinity"]).sort_values(
             ["i", "j"]
-        )
+            )
 
         _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
         _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -179,6 +179,8 @@ class TravelTimeReporter:
         self.land_use["nev_egress_available"] = (self.land_use["nev"] > 0) & (self.land_use["micro_accegr_dist"] <= self.constants["nevMaxDist"]) & (self.land_use["micro_accegr_dist"] >= self.constants["maxWalkIfMTAccessAvailable"])
         self.land_use["nev_accegr_time"] = 60 * self.land_use["micro_accegr_dist"] / self.constants["nevSpeed"]
 
+        self.expansion_matrix = pd.get_dummies(self.land_use["TAZ"]) # Indicates which MGRAs belong to which TAZ
+
     # # # # # # # # # # # # UTILITY FUNCTIONS # # # # # # # # # # # #
     #===============================================================#
     def field2matrix(self, field, origin = True):
@@ -222,9 +224,8 @@ class TravelTimeReporter:
         expanded_skim (pandas.DataFrame):
             Skim matrix where the index and columns are the origins and destinations MGRAs, respectively, and the values are the impedance from each origin MGRA to the destination MGRA
         """
-        expansion_matrix = pd.get_dummies(self.land_use["TAZ"]) # Indicates which MGRAs belong to which TAZ
         return pd.DataFrame(
-            expansion_matrix.values.dot(skim.values).dot(expansion_matrix.T.values),
+            self.expansion_matrix.values.dot(skim.values).dot(self.expansion_matrix.T.values),
             self.land_use.index,
             self.land_use.index
         )

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -110,14 +110,18 @@ class TravelTimeReporter:
             "traffic_skims_AM.omx"
         )
         skims = omx.open_file(am_traffic_skim_file, "r")
-        for core in ["BIKE_TIME", "walkTime"]:
+        active_taz_skims = {
+            "BIKE_TIME": "taz_bike_time",
+            "walkTime": "taz_walk_time"
+        }
+        for core in active_taz_skims:
             skim_values = np.array(skims[core.format(self.settings["time_period"])])
             skim_values = np.where(
                 skim_values == 0,
                 self.settings["infinity"],
                 skim_values
             )
-            self.skims[core] = self.expand_skim(
+            self.skims[active_taz_skims[core]] = self.expand_skim(
                 pd.DataFrame(
                     skim_values,
                     zones,
@@ -445,16 +449,16 @@ class TravelTimeReporter:
         """
         if bike:
             mode = "bike"
-            skim = "BIKE_TIME"
+            skim = "taz_bike_time"
         else:
             mode = "walk"
-            skim = "walkTIME"
+            skim = "taz_walk_time"
 
-        self.skims["taz_time"] = self.unpivot_skim(skim)
-        self.skims[mode + "_time"] = np.where(
-            self.skims[mode + "_time"] == self.settings["infinity"],
-            self.skims["taz_time"],
-            self.skims[mode + "_time"]
+        self.results["taz_time"] = self.unpivot_skim(skim)
+        self.results[mode] = np.where(
+            self.results[mode] == self.settings["infinity"],
+            self.results["taz_time"],
+            self.results[mode]
         )
 
     # # # # # # # # # # # # OUTPUT FUNCTIONS # # # # # # # # # # # #
@@ -470,8 +474,8 @@ class TravelTimeReporter:
         self.results = pd.DataFrame(
             {
                 "transit": self.unpivot_skim("total_transit_time"),
-                "walk": self.skims["walk_time"].query("walkTime <= @time_threshold")["walkTime"],
-                "bike": self.skims["bike_time"].query("BIKE_TIME <= @time_threshold")["BIKE_TIME"],
+                "walk": self.skims["maz_walk_time"].query("walkTime <= @time_threshold")["walkTime"],
+                "bike": self.skims["maz_bike_time"].query("BIKE_TIME <= @time_threshold")["BIKE_TIME"],
                 "microtransit": self.unpivot_skim("microtransit_time"),
                 "nev": self.unpivot_skim("nev_time"),
 #                "drive_alone": self.unpivot_skim("drive_alone_time")
@@ -479,6 +483,9 @@ class TravelTimeReporter:
         ).reset_index().fillna(self.settings["infinity"]).sort_values(
             ["i", "j"]
         )
+
+        self.add_active_taz_time(bike = False)
+        self.add_active_taz_time(bike = True)
 
         _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
         _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -102,37 +102,11 @@ class TravelTimeReporter:
             
         skims.close()
 
-        # Read bike and walk times from AM traffic skim
-        am_traffic_skim_file = os.path.join(
-            self.model_run,
-            "output",
-            "skims",
-            "traffic_skims_AM.omx"
-        )
-        skims = omx.open_file(am_traffic_skim_file, "r")
-        active_taz_skims = {
-            "BIKE_TIME": "taz_bike_time",
-            "walkTime": "taz_walk_time"
-        }
-        for core in active_taz_skims:
-            skim_values = np.array(skims[core.format(self.settings["time_period"])])
-            skim_values = np.where(
-                skim_values == 0,
-                self.settings["infinity"],
-                skim_values
-            )
-            self.skims[active_taz_skims[core]] = self.expand_skim(
-                pd.DataFrame(
-                    skim_values,
-                    zones,
-                    zones
-                )
-            )
-
     def read_active_skims(self):
         """
         Reads active skims into memory as data frames
         """
+        # Read MAZ-level skims
         for skim_name in self.settings["active_skim_files"]:
             active_skims = pd.read_csv(
                 os.path.join(
@@ -152,6 +126,45 @@ class TravelTimeReporter:
             ).set_index(
                 ["i", "j"]
             )
+
+        # Read bike and walk times from AM traffic skim
+        am_traffic_skim_file = os.path.join(
+            self.model_run,
+            "output",
+            "skims",
+            "traffic_skims_AM.omx"
+        )
+        skims = omx.open_file(am_traffic_skim_file, "r")
+        zones = skims.mapping("zone_number").keys()
+        active_taz_skims = {
+            "BIKE_TIME": "taz_bike_time",
+            "walkTime": "taz_walk_time"
+        }
+        for core in active_taz_skims:
+            skim_values = np.array(skims[core.format(self.settings["time_period"])])
+            skim_values = np.where(
+                skim_values == 0,
+                self.settings["infinity"],
+                skim_values
+            )
+            self.skims[active_taz_skims[core]] = self.expand_skim(
+                pd.DataFrame(
+                    skim_values,
+                    zones,
+                    zones
+                )
+            )
+
+        # Replace TAZ-skim level values with MGRA-skim values if they are present
+        self.unpivot_skim("taz_bike_time")
+        self.unpivot_skim("taz_walk_time")
+        self.unpivot_skim("maz_bike_time")
+        self.unpivot_skim("maz_walk_time")
+
+        self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
+        self.skims["walk_time"] = self.skims["taz_walk_time"].copy()
+        self.skims["bike_time"].loc[self.skims["maz_bike_time"].index] = self.skims["maz_bike_time"]
+        self.skims["walk_time"].loc[self.skims["maz_walk_time"].index] = self.skims["maz_walk_time"]
 
     def init_land_use(self):
         """
@@ -422,31 +435,6 @@ class TravelTimeReporter:
         dest_terminal_time = self.field2matrix("terminal_time", origin = False)
         self.skims["drive_alone_time"] = orig_terminal_time + self.expand_skim(self.skims["SOV_NT_L_TIME__" + self.settings["time_period"]]) + dest_terminal_time
 
-    def add_active_taz_time(self, bike = True):
-        """
-        Adds the skim values for OD pairs not in the MAZ skim files and reads in the TAZ-level skim values.
-
-        Parameters
-        ----------
-        bike (bool):
-            If set to `True`, obtain the bike skim values. Otherwise obtain the walk skim values.
-        """
-        if bike:
-            mode = "bike"
-            skim = "taz_bike_time"
-        else:
-            mode = "walk"
-            skim = "taz_walk_time"
-
-        self.results["taz_time"] = self.unpivot_skim(skim)
-        self.results[mode] = np.where(
-            self.results[mode] == self.settings["infinity"],
-            self.results["taz_time"],
-            self.results[mode]
-        )
-
-        del self.results["taz_time"]
-
     # # # # # # # # # # # # OUTPUT FUNCTIONS # # # # # # # # # # # #
     #==============================================================#
     def coalesce_results(self):
@@ -460,8 +448,8 @@ class TravelTimeReporter:
         self.results = pd.DataFrame(
             {
                 "transit": self.unpivot_skim("total_transit_time"),
-                "walk": self.skims["maz_walk_time"].query("walkTime <= @time_threshold")["walkTime"],
-                "bike": self.skims["maz_bike_time"].query("BIKE_TIME <= @time_threshold")["BIKE_TIME"],
+                "walk": self.skims["walk_time"],
+                "bike": self.skims["bike_time"],
                 "microtransit": self.unpivot_skim("microtransit_time"),
                 "nev": self.unpivot_skim("nev_time"),
 #                "drive_alone": self.unpivot_skim("drive_alone_time")
@@ -469,9 +457,6 @@ class TravelTimeReporter:
         ).reset_index().fillna(self.settings["infinity"]).sort_values(
             ["i", "j"]
         )
-
-        self.add_active_taz_time(bike = False)
-        self.add_active_taz_time(bike = True)
 
         _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
         _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -162,9 +162,9 @@ class TravelTimeReporter:
         self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
         self.skims["walk_time"] = self.skims["taz_walk_time"].copy()
         for ix, row in self.skims["maz_bike_time"].iterrows():
-            self.skims["bike_time"].loc[ix] = self.skims["maz_bike_time"].loc[ix, "time"]
+            self.skims["bike_time"].loc[ix] = self.skims["maz_bike_time"].loc[ix, "BIKE_TIME"]
         for ix, row in self.skims["maz_walk_time"].iterrows():
-            self.skims["walk_time"].loc[ix] = self.skims["maz_walk_time"].loc[ix, "time"]
+            self.skims["walk_time"].loc[ix] = self.skims["maz_walk_time"].loc[ix, "walkTime"]
 
     def init_land_use(self):
         """

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -250,11 +250,13 @@ class TravelTimeReporter:
             id_vars = ["i"],
             var_name = "j",
             value_name = "time"
-        ).sort_values(
-            ["i", "j"]
-            ).set_index(
+        ).query(
+            "time <= @time_threshold"
+            ).sort_values(
                 ["i", "j"]
-                )["time"]
+                ).set_index(
+                    ["i", "j"]
+                    )["time"]
 
     # # # # # # # # # # # # CALCULATOR FUNCTIONS # # # # # # # # # # # #
     #==================================================================#
@@ -451,9 +453,7 @@ class TravelTimeReporter:
                 "nev": self.unpivot_skim("nev_time"),
 #                "drive_alone": self.unpivot_skim("drive_alone_time")
             }
-        ).query(
-            "time <= @time_threshold"
-            ).reset_index().fillna(self.settings["infinity"]).sort_values(
+        ).reset_index().fillna(self.settings["infinity"]).sort_values(
             ["i", "j"]
             )
 

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -162,9 +162,9 @@ class TravelTimeReporter:
         self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
         self.skims["walk_time"] = self.skims["taz_walk_time"].copy()
         for ix, row in self.skims["maz_bike_time"].iterrows():
-            self.skims["bike_time"].loc[ix, "time"] = self.skims["maz_bike_time"].loc[ix, "time"]
+            self.skims["bike_time"].loc[ix] = self.skims["maz_bike_time"].loc[ix, "time"]
         for ix, row in self.skims["maz_walk_time"].iterrows():
-            self.skims["walk_time"].loc[ix, "time"] = self.skims["maz_walk_time"].loc[ix, "time"]
+            self.skims["walk_time"].loc[ix] = self.skims["maz_walk_time"].loc[ix, "time"]
 
     def init_land_use(self):
         """

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -156,8 +156,8 @@ class TravelTimeReporter:
             )
 
         # Replace TAZ-skim level values with MGRA-skim values if they are present
-        self.unpivot_skim("taz_bike_time")
-        self.unpivot_skim("taz_walk_time")
+        self.skims["taz_bike_time"] = self.unpivot_skim("taz_bike_time")
+        self.skims["taz_walk_time"] = self.unpivot_skim("taz_walk_time")
 
         self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
         self.skims["walk_time"] = self.skims["taz_walk_time"].copy()

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -114,7 +114,7 @@ class TravelTimeReporter:
             skim_values = np.array(skims[core.format(self.settings["time_period"])])
             skim_values = np.where(
                 skim_values == 0,
-                self.ssettings["infinity"],
+                self.settings["infinity"],
                 skim_values
             )
             self.skims[core] = self.expand_skim(

--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -158,8 +158,6 @@ class TravelTimeReporter:
         # Replace TAZ-skim level values with MGRA-skim values if they are present
         self.unpivot_skim("taz_bike_time")
         self.unpivot_skim("taz_walk_time")
-        self.unpivot_skim("maz_bike_time")
-        self.unpivot_skim("maz_walk_time")
 
         self.skims["bike_time"] = self.skims["taz_bike_time"].copy()
         self.skims["walk_time"] = self.skims["taz_walk_time"].copy()

--- a/src/main/python/datalake_exporter.py
+++ b/src/main/python/datalake_exporter.py
@@ -235,8 +235,8 @@ def write_to_datalake(output_path, models, exclude, env):
         os.path.abspath(os.path.join(output_path, '..', 'input', 'zone_term.csv')),
         os.path.abspath(os.path.join(output_path, '..', 'input', 'trlink.csv')),
         os.path.join(output_path, 'bikeMgraLogsum.csv'),
-        os.path.join(report_path, 'walkMgrasWithin45Min_AM.csv'),
-        os.path.join(report_path, 'walkMgrasWithin45Min_MD.csv')
+        os.path.join(report_path, 'walkMgrasWithin30Min_AM.csv'),
+        os.path.join(report_path, 'walkMgrasWithin30Min_MD.csv')
     ]
     for file in other_files:
         try:


### PR DESCRIPTION
## Proposed changes

The MAZ-level bike and walk skims don't include all OD-pairs that can be accessed by those modes. This adds TAZ-level skims for OD-pairs that the MAZ-level skims show as unavailable.

## Impact

More MGRA pairs should be available by bike and walking, increasing the number of opportunities in performance measures using those skims (such as jobs accessible by walking). Test results can be seen at T:\ABM\user\jflo\projects\ABM3\TravelTimeReporter\TestOutput30October.

## Types of changes

What types of changes does your code introduce to ABM?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] A test of the Travel Time Reporter was run in Emme.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
