### PR TITLE
Fix MAZ-Stop walk times

### DIFF
--- a/src/asim/scripts/resident/2zoneSkim_params.yaml
+++ b/src/asim/scripts/resident/2zoneSkim_params.yaml
@@ -28,8 +28,8 @@ mmms:
     mmms_link_len: "Shape_Leng"
     max_maz_maz_walk_dist_feet: 15840
     max_maz_maz_bike_dist_feet: 26400
-    max_maz_local_bus_stop_walk_dist_feet: 5280     # 1 mile
-    max_maz_premium_transit_stop_walk_dist_feet: 6336   # 1.2 miles
+    max_maz_local_bus_stop_walk_dist_feet: 23760     # 4.5 miles (allow microtransit)
+    max_maz_premium_transit_stop_walk_dist_feet: 23760   # 4.5 miles (allow microtransit)
     walk_speed_mph: 3.0
     drive_speed_mph: 25.0
     maz_maz_walk_output: "maz_maz_walk.csv"

--- a/src/asim/scripts/scenarioManagement/scenManagement.py
+++ b/src/asim/scripts/scenarioManagement/scenManagement.py
@@ -92,9 +92,3 @@ doc['FLEET_YEAR'] = int(scenYear)
 doc['CONSTANTS']['scenarioYear'] = int(scenYear)
 doc['CONSTANTS']['CHARGERS_PER_CAP'] = int(paramByYear.loc[paramByYear.year==scenYearWithSuffix, 'ev.chargers'].values[0]) / population
 util.write_yaml(_join(configs_dir, 'resident', 'vehicle_type_choice.yaml'), doc)
-
-sandag_abm_prop = util.load_properties(sandag_abm_prop_dir)
-doc = util.open_yaml(_join(scripts_dir, 'resident', '2zoneSkim_params.yaml'))
-doc['mmms']['max_maz_local_bus_stop_walk_dist_feet'] = float(sandag_abm_prop['microtransit.transit.connector.max.length'][0]) * 5280        # converting mile to feet
-doc['mmms']['max_maz_premium_transit_stop_walk_dist_feet'] = float(sandag_abm_prop['microtransit.transit.connector.max.length'][1]) * 5280  # converting mile to feet
-util.write_yaml(_join(scripts_dir, 'resident', '2zoneSkim_params.yaml'), doc)

--- a/src/main/resources/sandag_abm.properties
+++ b/src/main/resources/sandag_abm.properties
@@ -158,8 +158,6 @@ htm.input.file = inputs_sandag_HTM_${year}.xlsx
 transponder.destinations = 4027,2563,2258
 #traffic.sla_limit = 3
 #
-## maximum length of transit connectors in miles. The first value is for Local and the second is for PRM transit modes
-microtransit.transit.connector.max.length = 4.5,4.5
 walk.transit.connector.max.length = 0.85,1.2
 pnr.transit.connector.max.length = 10,10
 knr.transit.connector.max.length = 5,5


### PR DESCRIPTION
## Proposed changes

Maximum MAZ-Stop walk distance was set in sandag_abm.properties and updated in 2zoneSkim parameters by scenario management. 2zoneSkim is now run before scenario management, so this is not viable. To fix this, the max distance has been moved back to 2zoneSkim parameters

## Impact

Fix incorrect MAZ-Stop walk distance being applied. Should resolve high transit ridership

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Currently untested, no issues expected. Will check maz_stop_walk.csv once a scenario is run with this fix applied

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings