### PR TITLE
Remove "Skip copy of bike logsum"

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -291,7 +291,6 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         skipInitialization = props["RunModel.skipInitialization"]
         deleteAllMatrices = props["RunModel.deleteAllMatrices"]
         skipCopyWarmupTripTables = props["RunModel.skipCopyWarmupTripTables"]
-        skipCopyBikeLogsum = props["RunModel.skipCopyBikeLogsum"]
         skipBikeLogsums = props["RunModel.skipBikeLogsums"]
         skipBuildNetwork = props["RunModel.skipBuildNetwork"]
         skipHighwayAssignment = props["RunModel.skipHighwayAssignment"]
@@ -526,7 +525,9 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 if not skipBikeLogsums:
                     self.run_proc("runSandagBikeLogsums.cmd", [drive, path_forward_slash],
                                   "Bike - create AT logsums and impedances")
-                if not skipCopyBikeLogsum:
+                    # Copy updated logsums to scenario input to avoid overwriting
+                    self.copy_files(["bikeMgraLogsum.csv", "bikeTazLogsum.csv"], output_dir, input_dir)
+                elif not os.path.exists(_join(output_dir, "bikeMgraLogsum.csv")):
                     self.copy_files(["bikeMgraLogsum.csv", "bikeTazLogsum.csv"], input_dir, output_dir)
 
             else:

--- a/src/main/emme/toolbox/utilities/properties.py
+++ b/src/main/emme/toolbox/utilities/properties.py
@@ -38,7 +38,6 @@ class PropertiesSetter(object):
     deleteAllMatrices = _m.Attribute(bool)
     skipCopyWarmupTripTables = _m.Attribute(bool)
     skipBikeLogsums = _m.Attribute(bool)
-    skipCopyBikeLogsum = _m.Attribute(bool)
     skipTransitConnector = _m.Attribute(bool)
 
     skipHighwayAssignment_1 = _m.Attribute(bool)
@@ -157,7 +156,7 @@ class PropertiesSetter(object):
         self._run_model_names = (
             "env", "useLocalDrive", "skipMGRASkims", "skip4Ds", "skipInputChecker",
             "startFromIteration", "skipInitialization", "deleteAllMatrices", "skipCopyWarmupTripTables",
-            "skipCopyBikeLogsum", "skipBikeLogsums", "skipBuildNetwork",
+            "skipBikeLogsums", "skipBuildNetwork",
             "skipHighwayAssignment", "skipTransitSkimming", "skipTransitConnector", "skipTransponderExport", "skipScenManagement", "skipABMPreprocessing", "skipABMResident", "skipABMAirport", "skipABMXborderWait", "skipABMXborder", "skipABMVisitor", "skipMAASModel",
             "skipCVMEstablishmentSyn", "skipCTM", "skipTruck", "skipEI", "skipExternal", "skipTripTableCreation", "skipFinalHighwayAssignment",
             "skipFinalTransitAssignment", "skipVisualizer", "skipDataExport", "skipValidation", "skipDatalake", "skipDataLoadRequest",
@@ -217,7 +216,6 @@ class PropertiesSetter(object):
             ("deleteAllMatrices",       "&nbsp;&nbsp;&nbsp;&nbsp;Delete all matrices"),
             ("skipCopyWarmupTripTables","Skip import of warmup trip tables"),
             ("skipBikeLogsums",         "Skip bike logsums"),
-            ("skipCopyBikeLogsum",      "Skip copy of bike logsum"),
         ]
         skip_per_iteration_items = [
             ("skipHighwayAssignment",   "Skip highway assignments and skims"),
@@ -363,7 +361,6 @@ class PropertiesSetter(object):
         self.deleteAllMatrices = props.get("RunModel.deleteAllMatrices", False)
         self.skipCopyWarmupTripTables = props.get("RunModel.skipCopyWarmupTripTables", False)
         self.skipBikeLogsums = props.get("RunModel.skipBikeLogsums", False)
-        self.skipCopyBikeLogsum = props.get("RunModel.skipCopyBikeLogsum", False)
 
         self.skipHighwayAssignment = props.get("RunModel.skipHighwayAssignment", [False, False, False])
         self.skipTransitSkimming = props.get("RunModel.skipTransitSkimming", [False, False, False])
@@ -410,7 +407,6 @@ class PropertiesSetter(object):
         props["RunModel.skipCopyWarmupTripTables"] = self.skipCopyWarmupTripTables
        
         props["RunModel.skipBikeLogsums"] = self.skipBikeLogsums
-        props["RunModel.skipCopyBikeLogsum"] = self.skipCopyBikeLogsum
         props["RunModel.skipHighwayAssignment"] = self.skipHighwayAssignment
         props["RunModel.skipTransitSkimming"] = self.skipTransitSkimming
         props["RunModel.skipTransitConnector"] = self.skipTransitConnector

--- a/src/main/python/pythonGUI/parameterEditor.py
+++ b/src/main/python/pythonGUI/parameterEditor.py
@@ -27,7 +27,7 @@ class ParametersGUI(Tkinter.Frame):
             rbLabels=(u"Copy warm start trip tables:",u"Copy bike AT access files:",u"Create bike AT access files:",u"Build highway network:",u"Build transit network:",u"Run highway assignment:",
                       u"Run highway skimming:",u"Run transit assignment:",u"Run transit skimming:",u"Export results to CSVs:",u"Load results to database:")
             #properties
-            self.properties=("RunModel.skipCopyWarmupTripTables","RunModel.skipCopyBikeLogsum","RunModel.skipBikeLogsums","RunModel.skipBuildHwyNetwork","RunModel.skipBuildTransitNetwork","RunModel.skipFinalHighwayAssignment",
+            self.properties=("RunModel.skipCopyWarmupTripTables","RunModel.skipBikeLogsums","RunModel.skipBuildHwyNetwork","RunModel.skipBuildTransitNetwork","RunModel.skipFinalHighwayAssignment",
                           "RunModel.skipFinalHighwaySkimming","RunModel.skipFinalTransitAssignment","RunModel.skipFinalTransitSkimming",
                           "RunModel.skipDataExport","RunModel.skipDataLoadRequest")
 

--- a/src/main/resources/sandag_abm.properties
+++ b/src/main/resources/sandag_abm.properties
@@ -31,7 +31,6 @@ RunModel.deleteAllMatrices = false
 RunModel.skip4Ds = false
 RunModel.skipInputChecker = true
 RunModel.skipCopyWarmupTripTables = false
-RunModel.skipCopyBikeLogsum = false
 RunModel.skipShadowPricing = false
 RunModel.skipBikeLogsums = true
 RunModel.skipCopyWalkImpedance = true


### PR DESCRIPTION
## Proposed changes

Combines functionality of "Skip bike logsums" and "Skip copy of bike logsum" options. If "Skip bike logsums" is checked and bike logsums are not found in output, they will be copied from input

## Impact

Removes unintuitive behavior where new logsums would be overwritten by old logsums when both options were checked.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran scenario with "Skip bike logsums" checked, unchecked, then checked again. Confirmed old logsums were copied when checked, new logsums were generated when unchecked, and old logsums were not copied when checked again after generating

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings