### PR TITLE
Add option to skip travel time reporter

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -320,6 +320,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         skipFinalTransitAssignment = props["RunModel.skipFinalTransitAssignment"]
         skipVisualizer = props["RunModel.skipVisualizer"]
         skipDataExport = props["RunModel.skipDataExport"]
+        skipTravelTimeReporter = props["RunModel.skipTravelTimeReporter"]
         skipValidation = props["RunModel.skipValidation"]
         skipDatalake = props["RunModel.skipDatalake"]
         skipDataLoadRequest = props["RunModel.skipDataLoadRequest"]
@@ -782,6 +783,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 [drive, drive + path_forward_slash],
                 "Exporting highway shapefile", capture_output=True)
             
+        if not skipTravelTimeReporter:
             self.run_proc(
                 "run_travel_time_calculator.cmd",
                 [drive, drive + path_forward_slash],

--- a/src/main/emme/toolbox/utilities/properties.py
+++ b/src/main/emme/toolbox/utilities/properties.py
@@ -89,6 +89,7 @@ class PropertiesSetter(object):
     skipFinalTransitAssignment = _m.Attribute(bool)
     skipVisualizer = _m.Attribute(bool)
     skipDataExport = _m.Attribute(bool)
+    skipTravelTimeReporter = _m.Attribute(bool)
     skipValidation = _m.Attribute(bool)
     skipDatalake = _m.Attribute(bool)
     skipDataLoadRequest = _m.Attribute(bool)
@@ -158,7 +159,7 @@ class PropertiesSetter(object):
             "skipBikeLogsums", "skipBuildNetwork",
             "skipHighwayAssignment", "skipTransitSkimming", "skipTransitConnector", "skipTransponderExport", "skipScenManagement", "skipABMPreprocessing", "skipABMResident", "skipABMAirport", "skipABMXborderWait", "skipABMXborder", "skipABMVisitor", "skipMAASModel",
             "skipCVMEstablishmentSyn", "skipCTM", "skipTruck", "skipEI", "skipExternal", "skipTripTableCreation", "skipFinalHighwayAssignment",
-            "skipFinalTransitAssignment", "skipVisualizer", "skipDataExport", "skipValidation", "skipDatalake", "skipDataLoadRequest",
+            "skipFinalTransitAssignment", "skipVisualizer", "skipDataExport", "skipTravelTimeReporter", "skipValidation", "skipDatalake", "skipDataLoadRequest",
             "skipDeleteIntermediateFiles")
         self._properties = None
 
@@ -240,6 +241,7 @@ class PropertiesSetter(object):
             ("skipFinalTransitAssignment",  "Skip final transit assignments"),
             ("skipVisualizer",              "Skip running visualizer"),
             ("skipDataExport",              "Skip data export"),
+            ("skipTravelTimeReporter",      "Skip travel time reporter"),
             ("skipValidation",              "Skip validation"),
             ("skipDatalake",                "Skip write to datalake"),
             ("skipDataLoadRequest",         "Skip data load request"),
@@ -383,6 +385,7 @@ class PropertiesSetter(object):
         self.skipFinalTransitAssignment = props.get("RunModel.skipFinalTransitAssignment", False)
         self.skipVisualizer = props.get("RunModel.skipVisualizer", False)
         self.skipDataExport = props.get("RunModel.skipDataExport", False)
+        self.skipTravelTimeReporter = props.get("RunModel.skipTravelTimeReporter", False)
         self.skipValidation = props.get("RunModel.skipValidation", False)
         self.skipDatalake = props.get("RunModel.skipDatalake", False)
         self.skipDataLoadRequest = props.get("RunModel.skipDataLoadRequest", False)
@@ -426,6 +429,7 @@ class PropertiesSetter(object):
         props["RunModel.skipFinalTransitAssignment"] = self.skipFinalTransitAssignment
         props["RunModel.skipVisualizer"] = self.skipVisualizer
         props["RunModel.skipDataExport"] = self.skipDataExport
+        props["RunModel.skipTravelTimeReporter"] = self.skipTravelTimeReporter
         props["RunModel.skipValidation"] = self.skipValidation
         props["RunModel.skipDatalake"] = self.skipDatalake
         props["RunModel.skipDataLoadRequest"] = self.skipDataLoadRequest


### PR DESCRIPTION
## Proposed changes

Add checkbox in master run to skip travel time reporter. Previously was included in "skip data export"

## Impact

Travel time reporter takes a long time to run, so this lets us skip it for scenarios where we do not need to run access PM.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran scenario with option checked and unchecked

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
