### PR TITLE
Increased average work distance

### DIFF
--- a/src/asim/configs/resident/workplace_location_coefficients.csv
+++ b/src/asim/configs/resident/workplace_location_coefficients.csv
@@ -1,5 +1,5 @@
 coefficient_name,value,constrain
-coef_dist,0.27909,F
+coef_dist,0.285,F
 coef_dist_sqrt,-1.604,F
 coef_dist_sqrd,-0.004362,F
 coef_dist_cubed,0.00002365,F


### PR DESCRIPTION
## Proposed changes

[AB#1434](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/1434)

Increased average work distance from 11.2 to 11.5. This was done to help increase 2022 VMT back to target, in combination with https://github.com/SANDAG/ABM/pull/259, after it was greatly reduced by https://github.com/SANDAG/ABM/pull/251

## Impact

VMT increased by around 300k

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Re-ran iteration 3 of existing 2022 scenario, checked updated VMT and work distance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

Increasing external workplace location coef_dist_capped had no effect.

Increasing internal workplace location coef_dist from 0.27909 to 0.29 increased average work distance from 11.2 to 11.8, increasing VMT by 700k. This was about double the increase we wanted. so we tried half the adjustment at 0.285.

Increasing internal workplace location coef_dist from 0.27909 to 0.285 increased average work distance from 11.2 to 11.5, increasing VMT by 300k. This met the target we were aiming for.
