### PR TITLE
Added 2032 and 2040 to scenario year options in scenario creation GUI

### DIFF
--- a/src/main/python/pythonGUI/createStudyAndScenario.py
+++ b/src/main/python/pythonGUI/createStudyAndScenario.py
@@ -143,7 +143,7 @@ class CreateScenarioGUI(tkinter.Frame):
             tkinter.Label(body, text=u"Year", font=("Helvetica", 8, 'bold')).grid(row=current_row)
             var = tkinter.StringVar(root)
             #self.year="2016"
-            yearOptionList = ["2022","2026","2029","2035","2050"]
+            yearOptionList = ["2022","2026","2029","2032","2035","2040","2050"]
             #if self.select_lu:
             var.set(self.year)
             #else:


### PR DESCRIPTION
## Proposed changes

Adds 2032 and 2040 to the list of scenario years.

## Impact

When creating a scenario 2032 and 2040 are now listed as options.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] A test build was created and the GUI was run. The years 2032 and 2040 were present in the list of available scenarios and the default filepaths were updated appropriately.
![GUIUpdate1](https://github.com/user-attachments/assets/48a8f65a-5b77-4a48-aa11-b3ff7d03fee1)
![GUIUpdate2](https://github.com/user-attachments/assets/84d36528-dd37-4fcd-abc0-7f3d91bfb29e)
![GUIUpdate3](https://github.com/user-attachments/assets/4b0ca574-b9b2-497b-828c-752d4bc24098)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
