### PR TITLE
Assume owned ebike in travel time reporter

### DIFF
--- a/src/main/python/TravelTimeReporter.py
+++ b/src/main/python/TravelTimeReporter.py
@@ -484,7 +484,7 @@ class TravelTimeReporter:
         _ebikeMaxTime = self.constants["ebikeMaxDist"] / self.constants["ebikeSpeed"] * 60
         _escooterMaxTime = self.constants["escooterMaxDist"] / self.constants["escooterSpeed"] * 60
 
-        _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microRentTime"]
+        _ebikeTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["ebikeSpeed"]
         _escooterTime = self.results["bike"] * self.constants["bikeSpeed"] / self.constants["escooterSpeed"] + self.results["i"].map(self.land_use["MicroAccessTime"]) + self.constants["microRentTime"]
 
         self.results["ebike"] = np.where(


### PR DESCRIPTION
## Proposed changes

Planners have asked that ebike is assumed to be owned and not shared when calculating access metrics. This removes the micro access time and micro rent time from the ebike time calculation.

## Impact

More MGRAs should be accessible by ebike.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

This change has not been tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
