### PR TITLE
Recalibrate bike mode share for updated network

### DIFF
--- a/src/asim/configs/resident/tour_mode_choice_coefficients.csv
+++ b/src/asim/configs/resident/tour_mode_choice_coefficients.csv
@@ -437,7 +437,7 @@ coef_calib_distance_TNC_TRANSIT_atwork,-0.032,F
 coef_calib_zeroautohhindivtou_SHARED2_work,-1.0611602231451105,F
 coef_calib_zeroautohhindivtou_SHARED3_work,-4.1746,F
 coef_calib_zeroautohhindivtou_WALK_work,2.557215851820022,F
-coef_calib_zeroautohhindivtou_BIKE_work,-7.597671550291181,F
+coef_calib_zeroautohhindivtou_BIKE_work,-8.079656586782757,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_work,-1.000,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_work,-999.0,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_work,-4.075069451,F
@@ -448,7 +448,7 @@ coef_calib_zeroautohhindivtou_TNC_SHARED_work,-3.9627,F
 coef_calib_autodeficienthhind_SHARED2_work,-2.7731029168864034,F
 coef_calib_autodeficienthhind_SHARED3_work,-2.61696716883417,F
 coef_calib_autodeficienthhind_WALK_work,-0.704903616,F
-coef_calib_autodeficienthhind_BIKE_work,-6.323087073286013,F
+coef_calib_autodeficienthhind_BIKE_work,-6.805072109777588,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_work,-5.100,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_work,-8.541,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_work,-7.30,F
@@ -459,7 +459,7 @@ coef_calib_autodeficienthhind_TNC_SHARED_work,-9.6667,F
 coef_calib_autosufficienthhin_SHARED2_work,-2.621306584450577,F
 coef_calib_autosufficienthhin_SHARED3_work,-2.302972872840689,F
 coef_calib_autosufficienthhin_WALK_work,-3.868807014483816,F
-coef_calib_autosufficienthhin_BIKE_work,-3.662736117141059,F
+coef_calib_autosufficienthhin_BIKE_work,-4.144721153632634,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_work,-7.463386267911408,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_work,-9.50,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_work,-8.441000645946893,F
@@ -471,7 +471,7 @@ coef_calib_autosufficienthhin_TNC_SHARED_work,-11.9013,F
 coef_calib_zeroautohhindivtou_SHARED2_univ,1.4025215719623791,F
 coef_calib_zeroautohhindivtou_SHARED3_univ,-0.0017257324431166343,F
 coef_calib_zeroautohhindivtou_WALK_univ,-2.29788548,F
-coef_calib_zeroautohhindivtou_BIKE_univ,-0.8923227817104321,F
+coef_calib_zeroautohhindivtou_BIKE_univ,-1.3743078182020079,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_univ,0.7016008892584799,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_univ,-2.743,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_univ,-16.4728,F
@@ -482,7 +482,7 @@ coef_calib_zeroautohhindivtou_TNC_SHARED_univ,-999.0,F
 coef_calib_autodeficienthhind_SHARED2_univ,-2.8659437665920695,F
 coef_calib_autodeficienthhind_SHARED3_univ,-2.4044424666408846,F
 coef_calib_autodeficienthhind_WALK_univ,1.941902143,F
-coef_calib_autodeficienthhind_BIKE_univ,-5.136034055822561,F
+coef_calib_autodeficienthhind_BIKE_univ,-5.618019092314136,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_univ,-1.4664567331132938,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_univ,-8.2079,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_univ,-5.921932441559945,F
@@ -493,7 +493,7 @@ coef_calib_autodeficienthhind_TNC_SHARED_univ,-11.6732,F
 coef_calib_autosufficienthhin_SHARED2_univ,-2.743838372569629,F
 coef_calib_autosufficienthhin_SHARED3_univ,-2.5952628250266048,F
 coef_calib_autosufficienthhin_WALK_univ,1.940567696,F
-coef_calib_autosufficienthhin_BIKE_univ,-7.139816342291183,F
+coef_calib_autosufficienthhin_BIKE_univ,-7.621801378782758,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_univ,-7.800131433397487,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_univ,-7.940,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_univ,-8.0489,F
@@ -505,7 +505,7 @@ coef_calib_autosufficienthhin_TNC_SHARED_univ,-6.6511,F
 coef_calib_zeroautohhindivtou_SHARED2_school,-117.0,F
 coef_calib_zeroautohhindivtou_SHARED3_school,34.549978586276076,F
 coef_calib_zeroautohhindivtou_WALK_school,-6.461274242936103,F
-coef_calib_zeroautohhindivtou_BIKE_school,12.220528449708818,F
+coef_calib_zeroautohhindivtou_BIKE_school,11.738543413217242,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_school,-0.4078562423030851,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_school,-999.0,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_school,2.9447,F
@@ -517,7 +517,7 @@ coef_calib_zeroautohhindivtou_SCH_BUS_school,35.35537348509467,F
 coef_calib_autodeficienthhind_SHARED2_school,-5.560002977,F
 coef_calib_autodeficienthhind_SHARED3_school,-1.672317192000944,F
 coef_calib_autodeficienthhind_WALK_school,-0.6590523669067371,F
-coef_calib_autodeficienthhind_BIKE_school,-0.9935856862911833,F
+coef_calib_autodeficienthhind_BIKE_school,-1.4755707227827584,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_school,-141.40396559028179,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_school,-5.9201,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_school,-6.9559,F
@@ -529,7 +529,7 @@ coef_calib_autodeficienthhind_SCH_BUS_school,-2.257875674399108,F
 coef_calib_autosufficienthhin_SHARED2_school,-18.199635297754693,F
 coef_calib_autosufficienthhin_SHARED3_school,-3.4814411977218755,F
 coef_calib_autosufficienthhin_WALK_school,0.3649936466457807,F
-coef_calib_autosufficienthhin_BIKE_school,5.085923059384802,F
+coef_calib_autosufficienthhin_BIKE_school,4.603938022893227,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_school,-3.841696972180493,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_school,-10.5186,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_school,-8.7303,F
@@ -542,7 +542,7 @@ coef_calib_autosufficienthhin_SCH_BUS_school,-7.001927535992466,F
 coef_calib_zeroautohhindivtou_SHARED2_atwork,-105.0,F
 coef_calib_zeroautohhindivtou_SHARED3_atwork,-105.0,F
 coef_calib_zeroautohhindivtou_WALK_atwork,3.580527956,F
-coef_calib_zeroautohhindivtou_BIKE_atwork,-100.99537155029118,F
+coef_calib_zeroautohhindivtou_BIKE_atwork,-101.47735658678275,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_atwork,-92.10219724678387,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_atwork,-999.0,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_atwork,-999.0,F
@@ -553,7 +553,7 @@ coef_calib_zeroautohhindivtou_TNC_SHARED_atwork,-999.0,F
 coef_calib_autodeficienthhind_SHARED2_atwork,-1.1162833917345916,F
 coef_calib_autodeficienthhind_SHARED3_atwork,-0.08456716947692922,F
 coef_calib_autodeficienthhind_WALK_atwork,-3.280846444849632,F
-coef_calib_autodeficienthhind_BIKE_atwork,-14.781478250291185,F
+coef_calib_autodeficienthhind_BIKE_atwork,-15.26346328678276,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_atwork,-9.536775879,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_atwork,-999.0,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_atwork,-999.0,F
@@ -564,7 +564,7 @@ coef_calib_autodeficienthhind_TNC_SHARED_atwork,-10.87852298,F
 coef_calib_autosufficienthhin_SHARED2_atwork,-1.7815618345769157,F
 coef_calib_autosufficienthhin_SHARED3_atwork,-2.043005340889186,F
 coef_calib_autosufficienthhin_WALK_atwork,0.591874956,F
-coef_calib_autosufficienthhin_BIKE_atwork,-6.175231786291183,F
+coef_calib_autosufficienthhin_BIKE_atwork,-6.657216822782758,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_atwork,-9.968048166,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_atwork,-999.0,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_atwork,-999.0,F
@@ -576,7 +576,7 @@ coef_calib_autosufficienthhin_TNC_SHARED_atwork,-13.13094895,F
 coef_calib_zeroautohhindivtou_SHARED2_maint,-0.0953975040639451,F
 coef_calib_zeroautohhindivtou_SHARED3_maint,-0.5861750007692645,F
 coef_calib_zeroautohhindivtou_WALK_maint,2.5015568247527207,F
-coef_calib_zeroautohhindivtou_BIKE_maint,-6.013794118291184,F
+coef_calib_zeroautohhindivtou_BIKE_maint,-6.495779154782759,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_maint,0.254,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_maint,-999.0,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_maint,-0.954,F
@@ -589,7 +589,7 @@ coef_calib_zeroautohhindivtou_ESCOOTER_maint,-2.0910122923459893,F
 coef_calib_autodeficienthhind_SHARED2_maint,-0.427698775,F
 coef_calib_autodeficienthhind_SHARED3_maint,-0.135402405,F
 coef_calib_autodeficienthhind_WALK_maint,-0.680160963,F
-coef_calib_autodeficienthhind_BIKE_maint,-3.6668603578856263,F
+coef_calib_autodeficienthhind_BIKE_maint,-4.148845394377202,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_maint,-2.4511143207320331,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_maint,-4.300,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_maint,-3.250,F
@@ -602,7 +602,7 @@ coef_calib_autodeficienthhind_ESCOOTER_maint,-9.112007173155705,F
 coef_calib_autosufficienthhin_SHARED2_maint,-0.73368848,F
 coef_calib_autosufficienthhin_SHARED3_maint,-0.407647498,F
 coef_calib_autosufficienthhin_WALK_maint,-1.035931295266452,F
-coef_calib_autosufficienthhin_BIKE_maint,-1.29526326407825,F
+coef_calib_autosufficienthhin_BIKE_maint,-1.777248300569825,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_maint,-6.361456246944145,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_maint,-9.207,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_maint,-9.382658699,F
@@ -616,7 +616,7 @@ coef_calib_autosufficienthhin_ESCOOTER_maint,-9.112007173155705,F
 coef_calib_zeroautohhindivtou_SHARED2_disc,-0.24110458629661868,F
 coef_calib_zeroautohhindivtou_SHARED3_disc,-2.6123048389425985,F
 coef_calib_zeroautohhindivtou_WALK_disc,0.897642439,F
-coef_calib_zeroautohhindivtou_BIKE_disc,-3.3135222972911835,F
+coef_calib_zeroautohhindivtou_BIKE_disc,-3.795507333782758,F
 coef_calib_zeroautohhindivtou_WALK_TRANSIT_disc,0.350,F
 coef_calib_zeroautohhindivtou_PNR_TRANSIT_disc,-999.0,F
 coef_calib_zeroautohhindivtou_KNR_TRANSIT_disc,-5.211416276,F
@@ -629,7 +629,7 @@ coef_calib_zeroautohhindivtou_ESCOOTER_disc,-5.656387152155711,F
 coef_calib_autodeficienthhind_SHARED2_disc,-0.3753256374994909,F
 coef_calib_autodeficienthhind_SHARED3_disc,0.0532018185751006,F
 coef_calib_autodeficienthhind_WALK_disc,-1.594754179,F
-coef_calib_autodeficienthhind_BIKE_disc,-1.8788798717722444,F
+coef_calib_autodeficienthhind_BIKE_disc,-2.36086490826382,F
 coef_calib_autodeficienthhind_WALK_TRANSIT_disc,-0.512,F
 coef_calib_autodeficienthhind_PNR_TRANSIT_disc,-6.013662,F
 coef_calib_autodeficienthhind_KNR_TRANSIT_disc,-6.119248003,F
@@ -642,7 +642,7 @@ coef_calib_autodeficienthhind_ESCOOTER_disc,-6.302998778155713,F
 coef_calib_autosufficienthhin_SHARED2_disc,-0.6311678896592476,F
 coef_calib_autosufficienthhin_SHARED3_disc,0.2541481243589367,F
 coef_calib_autosufficienthhin_WALK_disc,-0.049841242,F
-coef_calib_autosufficienthhin_BIKE_disc,-1.9357090972911837,F
+coef_calib_autosufficienthhin_BIKE_disc,-2.417694133782759,F
 coef_calib_autosufficienthhin_WALK_TRANSIT_disc,-2.870,F
 coef_calib_autosufficienthhin_PNR_TRANSIT_disc,-7.132,F
 coef_calib_autosufficienthhin_KNR_TRANSIT_disc,-7.812,F
@@ -656,7 +656,7 @@ coef_calib_autosufficienthhin_ESCOOTER_disc,-8.74478202515571,F
 #coef_calib_zeroautohhjointtou_SHARED2_maint,8.507773009,F
 coef_calib_zeroautohhjointtou_SHARED3_maint,-65.0,F
 coef_calib_zeroautohhjointtou_WALK_maint,-42.051551929940764,F
-coef_calib_zeroautohhjointtou_BIKE_maint,-998.9953715502913,F
+coef_calib_zeroautohhjointtou_BIKE_maint,-999.4773565867827,F
 coef_calib_zeroautohhjointtou_WALK_TRANSIT_maint,-62.0,F
 coef_calib_zeroautohhjointtou_PNR_TRANSIT_maint,-999.0,F
 coef_calib_zeroautohhjointtou_KNR_TRANSIT_maint,-63.0,F
@@ -669,7 +669,7 @@ coef_calib_zeroautohhjointtou_ESCOOTER_maint,-58.11200717315571,F
 #coef_calib_autodeficienthhjoi_SHARED2_maint,15.5330624,F
 coef_calib_autodeficienthhjoi_SHARED3_maint,-48.16957674661429,F
 coef_calib_autodeficienthhjoi_WALK_maint,-48.63043930165117,F
-coef_calib_autodeficienthhjoi_BIKE_maint,-886.9953715502912,F
+coef_calib_autodeficienthhjoi_BIKE_maint,-887.4773565867829,F
 coef_calib_autodeficienthhjoi_WALK_TRANSIT_maint,-54.657619847723424,F
 coef_calib_autodeficienthhjoi_PNR_TRANSIT_maint,-55.90392356,F
 coef_calib_autodeficienthhjoi_KNR_TRANSIT_maint,-56.88159968,F
@@ -682,7 +682,7 @@ coef_calib_autodeficienthhjoi_ESCOOTER_maint,-55.11200717315571,F
 #coef_calib_autosufficienthhjo_SHARED2_maint,4.253195896,F
 coef_calib_autosufficienthhjo_SHARED3_maint,-4.175409902383396,F
 coef_calib_autosufficienthhjo_WALK_maint,-3.7539241053813464,F
-coef_calib_autosufficienthhjo_BIKE_maint,-17.422471860291186,F
+coef_calib_autosufficienthhjo_BIKE_maint,-17.90445689678276,F
 coef_calib_autosufficienthhjo_WALK_TRANSIT_maint,-20.27274185,F
 coef_calib_autosufficienthhjo_PNR_TRANSIT_maint,-18.77467449,F
 coef_calib_autosufficienthhjo_KNR_TRANSIT_maint,-16.58383844,F
@@ -696,7 +696,7 @@ coef_calib_autosufficienthhjo_ESCOOTER_maint,-19.112007173155703,F
 #coef_calib_zeroautohhjointtou_SHARED2_disc,8.507773009,F
 coef_calib_zeroautohhjointtou_SHARED3_disc,-70.24625539,F
 coef_calib_zeroautohhjointtou_WALK_disc,-56.051551929940764,F
-coef_calib_zeroautohhjointtou_BIKE_disc,-998.9953715502913,F
+coef_calib_zeroautohhjointtou_BIKE_disc,-999.4773565867827,F
 coef_calib_zeroautohhjointtou_WALK_TRANSIT_disc,-74.87568752,F
 coef_calib_zeroautohhjointtou_PNR_TRANSIT_disc,-999.0,F
 coef_calib_zeroautohhjointtou_KNR_TRANSIT_disc,-67.84999945,F
@@ -709,7 +709,7 @@ coef_calib_zeroautohhjointtou_ESCOOTER_disc,-57.8720071731557,F
 #coef_calib_autodeficienthhjoi_SHARED2_disc,10.5330624,F
 coef_calib_autodeficienthhjoi_SHARED3_disc,-48.16957674661429,F
 coef_calib_autodeficienthhjoi_WALK_disc,-48.63043930165117,F
-coef_calib_autodeficienthhjoi_BIKE_disc,-886.9953715502912,F
+coef_calib_autodeficienthhjoi_BIKE_disc,-887.4773565867829,F
 coef_calib_autodeficienthhjoi_WALK_TRANSIT_disc,-51.55258834772342,F
 coef_calib_autodeficienthhjoi_PNR_TRANSIT_disc,-53.1684399,F
 coef_calib_autodeficienthhjoi_KNR_TRANSIT_disc,-53.12678499,F
@@ -722,7 +722,7 @@ coef_calib_autodeficienthhjoi_ESCOOTER_disc,-54.8720071731557,F
 #coef_calib_autosufficienthhjo_SHARED2_disc,4.253195896,F
 coef_calib_autosufficienthhjo_SHARED3_disc,-2.175409902383395,F
 coef_calib_autosufficienthhjo_WALK_disc,-1.753924105381346,F
-coef_calib_autosufficienthhjo_BIKE_disc,-17.227773190291185,F
+coef_calib_autosufficienthhjo_BIKE_disc,-17.70975822678276,F
 coef_calib_autosufficienthhjo_WALK_TRANSIT_disc,-18.918341,F
 coef_calib_autosufficienthhjo_PNR_TRANSIT_disc,-15.46037795,F
 coef_calib_autosufficienthhjo_KNR_TRANSIT_disc,-22.31188559,F


### PR DESCRIPTION
## Proposed changes

AT network was updated to set default vehicle lanes to 1 instead of 0 for links with no lane info. The result was far more suburban and rural streets allowing bikes, greatly increasing bike mode share. This recalibration reduces overall bike tour mode share with the new network.

## Impact

Bike tour mode share:
- Pre-calibration: 2.05%
- Target: 1.47% (pre-update share)
- Calibration result: 1.46%

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Calibrated using full-sample resident model, tour_mode_choice_simulate through atwork_subtour_mode_choice only

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings