### PR TITLE
Force AV allocation to read escort_participants as string

### DIFF
--- a/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
+++ b/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
@@ -484,4 +484,4 @@ Description,Target,Expression
 ,origin_purpose,"np.where((trips.trip_count > 1) & (trips.trip_num==1) & (trips.outbound), 'home', origin_purpose)"
 ,origin_purpose,"np.where(((trips.trip_count > 1) & (trips.trip_num>1)) | ((trips.trip_count > 1) & (trips.trip_num==1) & ~(trips.outbound)), trips['purpose'].shift(1), origin_purpose)"
 #AV allocation model needs column to be entirely in string format,,
-,escort_participants,"np.where(trips.escort_participants.isna(),trips.escort_participants,'_'+trips.escort_participants)"
+,escort_participants,"np.where(trips.escort_participants.isna() | trips.escort_participants == '',trips.escort_participants,'_'+trips.escort_participants)"

--- a/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
+++ b/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
@@ -483,3 +483,5 @@ Description,Target,Expression
 ,origin_purpose,"np.where(trips.trip_count == 1 & (trips.primary_purpose == 'atwork'), 'work', origin_purpose)"
 ,origin_purpose,"np.where((trips.trip_count > 1) & (trips.trip_num==1) & (trips.outbound), 'home', origin_purpose)"
 ,origin_purpose,"np.where(((trips.trip_count > 1) & (trips.trip_num>1)) | ((trips.trip_count > 1) & (trips.trip_num==1) & ~(trips.outbound)), trips['purpose'].shift(1), origin_purpose)"
+#AV allocation model needs column to be entirely in string format,,
+,escort_participants,"np.where(np.isnan(trips.escort_participants),trips.escort_participants,'_'+trips.escort_participants)"

--- a/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
+++ b/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
@@ -484,4 +484,4 @@ Description,Target,Expression
 ,origin_purpose,"np.where((trips.trip_count > 1) & (trips.trip_num==1) & (trips.outbound), 'home', origin_purpose)"
 ,origin_purpose,"np.where(((trips.trip_count > 1) & (trips.trip_num>1)) | ((trips.trip_count > 1) & (trips.trip_num==1) & ~(trips.outbound)), trips['purpose'].shift(1), origin_purpose)"
 #AV allocation model needs column to be entirely in string format,,
-,escort_participants,"np.where(np.isnan(trips.escort_participants),trips.escort_participants,'_'+trips.escort_participants)"
+,escort_participants,"np.where(trips.escort_participants.isna(),trips.escort_participants,'_'+trips.escort_participants)"

--- a/src/asim/visualizer/visualizer/config/user_added_functions.py
+++ b/src/asim/visualizer/visualizer/config/user_added_functions.py
@@ -1,6 +1,6 @@
 def get_escort_participant_list(escort_participants):
     if type(escort_participants) == str:
-        return [int(participant) for participant in escort_participants.split('_')]
+        return [int(participant) for participant in escort_participants.split('_')[1:]]
     else:
         return []
 


### PR DESCRIPTION
## Proposed changes

TNC Routing / AV Allocation errors out when first row of the trips table has a numerical value for escort_participants, as the column also contains string values. To fix this, add an underscore to the start of all escort_participants values to force it to be read as string. Visualizer is updated to account for this extra underscore

## Impact

Prevent rare error in MAAS

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Run on cropped dataset

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
