### PR TITLE
Crash model if MAAS models fail

### DIFF
--- a/src/main/resources/runSandagAbm_MAAS.cmd
+++ b/src/main/resources/runSandagAbm_MAAS.cmd
@@ -42,11 +42,20 @@ ping -n 10 %MAIN% > nul
 cd %PROJECT_DRIVE%%PROJECT_DIRECTORY%
 
 rem TNC Fleet Model
-%JAVA_64_PATH%\bin\java -server -Xms%MEMORY_SPMARKET_MIN% -Xmx%MEMORY_SPMARKET_MAX% -cp "%CLASSPATH%" -Djxl.nowarnings=true -Dlog4j.configuration=log4j.xml -Dproject.folder=%PROJECT_DIRECTORY% org.sandag.abm.maas.TNCFleetModel %PROPERTIES_NAME% -iteration %ITERATION% -sampleRate %SAMPLERATE%
+%JAVA_64_PATH%\bin\java -server -Xms%MEMORY_SPMARKET_MIN% -Xmx%MEMORY_SPMARKET_MAX% -cp "%CLASSPATH%" -Djxl.nowarnings=true -Dlog4j.configuration=log4j.xml -Dproject.folder=%PROJECT_DIRECTORY% org.sandag.abm.maas.TNCFleetModel %PROPERTIES_NAME% -iteration %ITERATION% -sampleRate %SAMPLERATE% || goto error
 
 rem Household AV Allocation Model
-%JAVA_64_PATH%\bin\java -server -Xms%MEMORY_SPMARKET_MIN% -Xmx%MEMORY_SPMARKET_MAX% -cp "%CLASSPATH%" -Djxl.nowarnings=true -Dlog4j.configuration=log4j.xml -Dproject.folder=%PROJECT_DIRECTORY% org.sandag.abm.maas.HouseholdAVAllocationModelRunner %PROPERTIES_NAME% -iteration %ITERATION% -sampleRate %SAMPLERATE%
+%JAVA_64_PATH%\bin\java -server -Xms%MEMORY_SPMARKET_MIN% -Xmx%MEMORY_SPMARKET_MAX% -cp "%CLASSPATH%" -Djxl.nowarnings=true -Dlog4j.configuration=log4j.xml -Dproject.folder=%PROJECT_DIRECTORY% org.sandag.abm.maas.HouseholdAVAllocationModelRunner %PROPERTIES_NAME% -iteration %ITERATION% -sampleRate %SAMPLERATE% || goto error
 rem ### restore saved environment variable values, and change back to original current directory
 set JAVA_PATH=%OLDJAVAPATH%
 set PATH=%OLDPATH%
 set CLASSPATH=%OLDCLASSPATH%
+
+goto :EOF
+
+:error
+rem ### restore saved environment variable values, and change back to original current directory
+set JAVA_PATH=%OLDJAVAPATH%
+set PATH=%OLDPATH%
+set CLASSPATH=%OLDCLASSPATH%
+exit /b 2


### PR DESCRIPTION
## Proposed changes

Propagate errors from TNC routing or AV allocation models to master_run so that the model crashes if they fail.

Same implementation as asim preprocessing https://github.com/SANDAG/ABM/blob/ABM3_develop/src/main/resources/runSandagAbm_Preprocessing.cmd

## Impact

Model will crash instead of failing silently if MAAS models encounter an error

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran the script with no java file, script failed as intended. Error from missing java file should be comparable to error in java process

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
