### PR TITLE
Fix escort participants in visualizer

### DIFF
--- a/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
+++ b/src/asim/configs/resident/write_trip_matrices_annotate_trips_preprocessor.csv
@@ -484,4 +484,4 @@ Description,Target,Expression
 ,origin_purpose,"np.where((trips.trip_count > 1) & (trips.trip_num==1) & (trips.outbound), 'home', origin_purpose)"
 ,origin_purpose,"np.where(((trips.trip_count > 1) & (trips.trip_num>1)) | ((trips.trip_count > 1) & (trips.trip_num==1) & ~(trips.outbound)), trips['purpose'].shift(1), origin_purpose)"
 #AV allocation model needs column to be entirely in string format,,
-,escort_participants,"np.where(trips.escort_participants.isna() | trips.escort_participants == '',trips.escort_participants,'_'+trips.escort_participants)"
+,escort_participants,"np.where((trips.escort_participants.isna()) | (trips.escort_participants == ''),trips.escort_participants,'_'+trips.escort_participants)"


### PR DESCRIPTION
## Proposed changes

Visualizer crashed with recent changes to escort_participants due to "_" values: https://github.com/SANDAG/ABM/pull/274
Added parentheses appear to have fixed the issue

## Impact
No crash in visualizer

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Joe tested visualizer with this change and it did not crash 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
