### PR TITLE
Removed occFactors.csv from visualizer

### DIFF
--- a/src/asim/visualizer/visualizer/config/settings.yaml
+++ b/src/asim/visualizer/visualizer/config/settings.yaml
@@ -21,7 +21,6 @@ extract:
       data:
           - "households.csv"
           - "land_use.csv"
-          - "occFactors.csv"
     - filepath: "../../../../output/skims"
       test_size:
       data:


### PR DESCRIPTION
## Proposed changes

Edits the calibration visualizer settings to not read in occFactors.csv, as that file has been difficult to manage and it turns out is not needed at all.

## Impact

The visualizer will no longer crash if occFactors.csv is not present in the model run's input directory.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

- [x] File was commented out of list of input files in visualizer settings and the visualizer was run on an old model run without crashing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
