### PR TITLE
Docs site restructure to include a new section on calibration and validation

### DIFF
--- a/docs/calib_valid/calib_overview.md
+++ b/docs/calib_valid/calib_overview.md
@@ -1,0 +1,3 @@
+# Calibration and Validation Overview
+
+Overview of calibration and validation processes.

--- a/docs/calib_valid/calibration.md
+++ b/docs/calib_valid/calibration.md
@@ -1,0 +1,3 @@
+# Calibration
+
+Calibration details.

--- a/docs/calib_valid/convergence.md
+++ b/docs/calib_valid/convergence.md
@@ -1,0 +1,3 @@
+# Convergence
+
+Convergence details.

--- a/docs/calib_valid/validation.md
+++ b/docs/calib_valid/validation.md
@@ -1,0 +1,3 @@
+# Validation
+
+Validation details.

--- a/docs/design/demand/cvm.md
+++ b/docs/design/demand/cvm.md
@@ -1,3 +1,5 @@
+# Commercial Vehicle Model
+
 #### Introduction
 The SANDAG Commercial Vehicle Model (CVM) simulates the weekday demand patterns of commercial 
 vehicle movements throughout the San Diego region. The CVM is an important part of the complete travel 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
         - design/demand/crossborder.md
         - design/demand/airport.md
         - design/demand/visitor.md
+        - design/demand/cvm.md
         - design/demand/external.md
     - Supply: 
         - design/supply/index.md
@@ -81,7 +82,11 @@ nav:
     - Flexible Fleets: application/flexible-fleets.md
     - Micromobility: application/micromobility.md
     - Network Coding: application/network-coding.md
-  - Commercial Vehicle Model: cvm.md
+  - Calibration and Validation:
+    - Overview: calib_valid/calib_overview.md
+    - Calibration: calib_valid/calibration.md
+    - Convergence: calib_valid/convergence.md
+    - Validation: calib_valid/validation.md
   - About:
     - Release Notes: release-notes.md
     - FAQs: faq.md


### PR DESCRIPTION
## Proposed changes

Create a new section in the top navigation bar for calibration and validation. Move the commercial vehicle demand page to "model design" section for now.

## Impact

Calibration and validation is more important and merits a separate section in the navigation bar. It will be easier for users to find those details from the home page.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Changes tested on local git branch

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

None.
