### PR TITLE
Update running.md to fix image referencing

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -193,7 +193,7 @@ To verify successful installation of sqlcmd utility on your workstation:
 
 <br>
 <div align="center">
-    <img src="images\running\sqlcmd_test.jpg" alt="alt_text" title="image_tooltip">
+    <img src="images\running\sqlcmd_test.JPG" alt="alt_text" title="image_tooltip">
     <br>
     <em>SQLCMD Utility Test</em>
 </div>
@@ -255,7 +255,7 @@ The *Master Run* tool allows the user to run all or part of the model, and set a
 
 <br>
 <div align="center">
-    <img src="images\running\master_run.jpg" alt="alt_text" title="image_tooltip">
+    <img src="images\running\master_run.JPG" alt="alt_text" title="image_tooltip">
     <br>
     <em>Master Run tool</em>
 </div>
@@ -274,7 +274,7 @@ By expanding the *Run model – skip steps* drop down, the user has the option t
 
 <br>
 <div align="center">
-    <img src="images\running\master_run_skip_steps.jpg" alt="alt_text" title="image_tooltip">
+    <img src="images\running\master_run_skip_steps.JPG" alt="alt_text" title="image_tooltip">
     <br>
     <em>Run model tool</em>
 </div>


### PR DESCRIPTION
## Proposed changes

Fixed broken image references where .jpg extensions needed to be capitalized to .JPG for newly uploaded images under [Pull Request #299](https://github.com/SANDAG/ABM/pull/299).

## Impact

All images should now be correctly displayed within the wiki page.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

- [x] Used a Markdown preview to verify images were being displayed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

None