### PR TITLE
Fix output directory mistake in bike logsum documentation

### DIFF
--- a/docs/design/supply/bike-logsums.md
+++ b/docs/design/supply/bike-logsums.md
@@ -4,7 +4,7 @@
 
 This model generates bike logsums and times for MGRA and TAZ pairs. It is designed to reflect the impact of bike infrastructure on path and mode choice for bicycle trips. It identifies likely routes along the all-streets network, considering factors such as presence and type of bike lane, turns, and gain in elevation. Note that the Bike mode uses bike logsums, while Ebike and Escooter use bike times.
 
-This process generates the input\bikeMgraLogsum.csv and input\bikeTazLogsum.csv files. Bike logsums only need to be run when the active transportation (AT) network is updated. If logsums do not need to be updated, use the "Skip bike logsums" setting to automatically copy from the T:\ABM\release\ABM\version_X_X_X\input\20XX directory. This directory is updated manually.
+This process generates the output\bikeMgraLogsum.csv and output\bikeTazLogsum.csv files. Bike logsums only need to be run when the active transportation (AT) network is updated. If logsums do not need to be updated, use the "Skip bike logsums" setting to automatically copy from input\bikeMgraLogsum.csv and input\bikeTazLogsum.csv, sourced from T:\ABM\release\ABM\version_X_X_X\input\20XX. This directory is updated manually.
 
 ## Design
 
@@ -26,7 +26,7 @@ This process generates the input\bikeMgraLogsum.csv and input\bikeTazLogsum.csv 
 
 **Path Choice Utility Calculation:** Calculate bike logsum values for each origin/destination pair from utility expression on each path alternative.
 
-**Outputs:** Bike logsums and times are written to input\bikeMgraLogsum.csv and input\bikeTazLogsum.csv. During ActivitySim preprocessing, TAZ values are added to BIKE_LOGSUM and BIKE_TIME matrices of output\skims\traffic_skims_AM.omx and MGRA values are written to output\skims\maz_maz_bike.csv.
+**Outputs:** Bike logsums and times are written to output\bikeMgraLogsum.csv and output\bikeTazLogsum.csv. During ActivitySim preprocessing, TAZ values are added to BIKE_LOGSUM and BIKE_TIME matrices of output\skims\traffic_skims_AM.omx and MGRA values are written to output\skims\maz_maz_bike.csv.
 
 ## Further reading
 


### PR DESCRIPTION
## Proposed changes

Documentation mistakenly claimed that bike logsum process wrote outputs to the input folder. This has been fixed, with clarification on how files are copied from input folder when skipping this process.

## Impact

Fixes mistake in documentation

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] No test necessary

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
