### PR TITLE
Fix reading vehicle_class_toll_factors.csv

### DIFF
--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -1345,7 +1345,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                     self._error.append(msg)
         else:
             fatal_errors += 1
-            msg = ("Vehicle class factor file %s not found").format(vehicle_class_factor_file)
+            msg = ("Vehicle class factor file {} not found").format(vehicle_class_factor_file)
             self._log.append({"type": "text", "content": msg})
             self._error.append(msg)
 

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -43,8 +43,7 @@
 #    mode5tod.csv: global (per-mode) transit cost and perception attributes
 #    timexfer_<period>.csv (optional): table of timed transfer pairs of lines, by period
 #    special_fares.txt (optional): table listing special fares in terms of boarding and incremental in-vehicle costs.
-#    off_peak_toll_factors.csv (optional): factors to calculate the toll for EA, MD, and EV periods from the OP toll input for specified facilities
-#    vehicle_class_toll_factors.csv (optional): factors to adjust the toll cost by facility name and class (DA, S2, S3, TRK_L, TRK_M, TRK_H)
+#    vehicle_class_toll_factors.csv: factors to adjust the toll cost by facility name and class (DA, S2, S3, TRK_L, TRK_M, TRK_H)
 #
 #
 # Script example:
@@ -93,7 +92,6 @@ dem_utils = _m.Modeller().module("sandag.utilities.demand")
 FILE_NAMES = {
     "FARES": "special_fares.txt",
     "TIMEXFER": "timexfer_%s.csv",
-    "OFF_PEAK": "off_peak_toll_factors.csv",
     "VEHICLE_CLASS": "vehicle_class_toll_factors.csv",
     "MODE5TOD": "MODE5TOD.csv",
 }
@@ -160,8 +158,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 <li>mode5tod.csv</li>
                 <li>timexfer_<period>.csv (optional)</li>
                 <li>special_fares.txt (optional)</li>
-                <li>off_peak_toll_factors.csv (optional)</li>
-                <li>vehicle_class_toll_factors.csv (optional)</li>
+                <li>vehicle_class_toll_factors.csv</li>
             </ul>
         </div>
         """

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -1307,11 +1307,11 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
             },
             "count": 0
         }
-        if os.path.exists(_join(self.source, vehicle_class_factor_file)):
+        if os.path.exists(_join(_dir(self.source), vehicle_class_factor_file)):
             msg = "Adjusting tolls based on factors from %s" % vehicle_class_factor_file
             self._log.append({"type": "text", "content": msg})
             # NOTE: CSV Reader sets the field names to UPPERCASE for consistency
-            with gen_utils.CSVReader(_join(self.source, vehicle_class_factor_file)) as r:
+            with gen_utils.CSVReader(_join(_dir(self.source), vehicle_class_factor_file)) as r:
                 for row in r:
                     if "YEAR" in r.fields and int(row["YEAR"]) != scenario_year:  # optional year column
                         continue


### PR DESCRIPTION
## Proposed changes

#318
Updates import_network to read the toll factors file from the input directory instead of the network geodatabase. Also makes toll factors file required instead of optional and does not override HOV2 and HOV3 factors on HOV2 or HOV3 links if factors are defined in the file.

## Impact

Updates to vehicle_class_toll_factors.csv will be properly read into the model network rather than using defaults

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Check auto cost on an SR-125 link before and after changing toll factor in vehicle_class_toll_factors.csv
- [x] Check HOV2 and HOV3 costs on SR-15 (HOV2) use toll factors from vehicle_class_toll_factors.csv
- [x] Check HOV2 and HOV3 costs are overridden as 0 on SR-15 if removed from vehicle_class_toll_factors.csv
- [x] Check costs after defining different SR-15 factors by time of day
- [x] Run with no toll factors file and check network import fails

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

[AB#2073](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/2073)
