### PR TITLE
Update SDIA MGRAs to Series 15 

### DIFF
--- a/src/main/resources/abm3_settings.yaml
+++ b/src/main/resources/abm3_settings.yaml
@@ -257,14 +257,14 @@ airport:
           walkTime: -999
           waitTime: -999
         loc4:
-          mgra: 6528
+          mgra: 8455
           accessCost: 0.00
           dailyCost: 25.62
           inVehicleTime: 6.00
           walkTime: 2.00
           waitTime: 3.00
         loc5:
-          mgra: 2802
+          mgra: 1306
           accessCost: 0.00
           dailyCost: 25.62
           inVehicleTime: 6.00
@@ -278,7 +278,7 @@ airport:
         walkTime: 5.00
         waitTime: 0.00
       rental:
-        mgra: 2994
+        mgra: 11244
         accessCost: 0.00
         dailyCost: 60.99
         inVehicleTime: 7.50


### PR DESCRIPTION
Changed MGRA values for loc4, loc5, and rental in the SAN airport section of abm3_settings.yaml to reflect Series 15 MGRA values

## Proposed changes

The changes in this pull request update the SDIA access MGRA values for Rental Car Facility, Parking Location 4 and Parking Location 5 referenced in the SAN Airport Model. The values had been left unchanged when migrating from Series 14 to Series 15 and hence were spatially referencing locations that were not related to SAN Airport activities. 

The MGRAs were updated as follows:

| accessOptions           | Original Series 14  MGRA Value | Updated Series 15  MGRA Value |
|-----------|--------------------------------|-------------------------------|
| RENTAL    | 2994                           | 11244                         |
| PARK_LOC4 | 6528                           | 8455                          |
| PARK_LOC5 | 2802                           | 1306                          |

## Impact

After the access MGRA values were updated to Series 15 values, a base year scenario was ran and SAN Airport model outputs were summarized. 

Scenario 261 is the Draft 25 RP Base scenario (with Series 14 SAN access MGRAs) whereas scenario 359 is the scenario that has the updated SAN access Series 15 MGRAs.

Starting with VMT metrics, the MGRA updates resulted in the following changes:

| Scenario ID | Scenario | Regional VMT | SDIA VMT | 
|-----|-----|-----|-----|
| 261 | 2022_S0_v2 | 77,898,460 | 1,076,372|
| 359 | 2022_sdia_mgras_v2 | 77,957,101 | 1,083,999|

Next, total number of SAN trips and total number of person SAN trips:

| Scenario ID | Scenario           | weight_trip | weight_person_trip |
|-------------|--------------------|-------------|--------------------|
| 261         | 2022_S0_v2         |  56,263     |  97,271            |
| 359         | 2022_sdia_mgras_v2 |  55,989     |  96,261            |

And lastly, total number of SAN trips and total number of person SAN trips by the different access / arrival modes that the MGRAs were updated for:

|             |                     | Arrival Mode - weight_trip |           |           | Arrival Mode - weight_person_trip |           |            |
|-------------|---------------------|----------------------------|-----------|-----------|-----------------------------------|-----------|------------|
| Scenario ID | Scenario            | RENTAL                     | PARK_LOC4 | PARK_LOC5 | RENTAL                            | PARK_LOC4 | PARK_LOC5  |
| 261         | 2022_S0_v2          |  7,044                     |  817      |  1,106    |  12,304                           |  1,316    |  1,687     |
| 359         | 2022_sdia_mgras_v2  |  3,262                     |  1,240    |  1,322    |  5,722                            |  1,951    |  2,020     |

When the RENTAL access MGRA was left as Series 14, the number of trips were noted to increase significantly. Under Series 15, MGRA 2994 is in Hillcrest, whereas the intended location should be the CONRAC facility by SDIA. When looking at the Base (2016) ABM2+ 14.3.0 run (Scenario ID 186), with the RENTAL access MGRA set as 2994, the total number of person SAN trips came out to 4,427 and total SAN trips to 2,514 which appear more in agreement with scenario 359. 

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Created a scenario and updated the MGRA values. Scenario loaded as scenario id 359 in azure (15.3.0)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
