### PR TITLE
Issue 323: adjust link mode availability

### DIFF
--- a/src/main/emme/toolbox/assignment/traffic_assignment.py
+++ b/src/main/emme/toolbox/assignment/traffic_assignment.py
@@ -1008,30 +1008,7 @@ Assignment matrices and resulting network flows are always in PCE.
                     mode_type="AUX_AUTO", mode_id=gen_truck_mode,
                     mode_description="all trucks", scenario=scenario)
             change_link_modes(modes=[truck_mode], action="ADD",
-                              selection="modes=vVmMtT", scenario=scenario)
-            
-    #added by RSG (nagendra.dhakar@rsginc.com) for collapsed assignment classes testing
-    #this adds non-transponder SOV mode to SR-125 links
-    # TODO: move this to the network_import step for consistency and foward-compatibility
-    # Modified 10.10.24 by CAR based on suggestion from Kevin Bragg of Bentley so that it
-    # can handle networks that have no HOV = 4 links
-    def change_mode_sovntp(self, scenario):
-        modeller = _m.Modeller()
-        netcalc = modeller.tool(
-            "inro.emme.network_calculation.network_calculator")
-        change_link_modes = modeller.tool(
-            "inro.emme.data.network.base.change_link_modes")
-        spec = {
-            "type": "NETWORK_CALCULATION",
-            "expression": "1",
-            "selections": {"link": "@hov=4"}}
-        report = netcalc(spec, scenario=scenario, full_report=True)
-        if report["num_evaluations"] > 0:
-            with _m.logbook_trace("Preparation for sov ntp assignment"):
-                gen_sov_mode = 's'
-                sov_mode = scenario.mode(gen_sov_mode)
-                change_link_modes(modes=[sov_mode], action="ADD",
-                                  selection="@hov=4", scenario=scenario)            
+                              selection="modes=vVmMtT", scenario=scenario)         
 
     def report(self, period, scenario, classes):
         emmebank = scenario.emmebank

--- a/src/main/emme/toolbox/assignment/traffic_assignment.py
+++ b/src/main/emme/toolbox/assignment/traffic_assignment.py
@@ -429,11 +429,6 @@ Assignment matrices and resulting network flows are always in PCE.
                 },
             ]
             
-            # change mode to allow sovntp on SR125
-            # TODO: incorporate this into import_network instead
-            #       also, consider updating mode definitions
-            self.change_mode_sovntp(scenario)
-            
             if period == "MD" and (msa_iteration == 1 or not scenario.mode('D')):
                 self.prepare_midday_generic_truck(scenario)
 

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -575,6 +575,8 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 # managed lanes, free for HOV2 and HOV3+, tolls for SOV
                 if link[toll] > 0:
                     auto_modes =  lookup["TOLL"][link[truck]]
+                elif link.type == 8 or link.type == 9:
+                    auto_modes =  lookup["TOLL"][link[truck]]
                 if link["@hov"] == 2:
                     auto_modes = auto_modes | lookup["HOV2"]
                 else:

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -586,7 +586,7 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                     auto_modes = auto_modes | lookup["HOV3"]
             elif link["@hov"] == 4:
                 # adding 's' so that non-transponder SOVs can use toll roads by paying cash
-                auto_modes =  lookup["TOLL"][link[truck]] + set([network.mode(m_id) for m_id in "s"])
+                auto_modes =  lookup["TOLL"][link[truck]] | set([network.mode(m_id) for m_id in "s"])
             link.modes = link.transit_modes | auto_modes
 
     def create_road_base(self, network, attr_map):

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -585,7 +585,8 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 else:
                     auto_modes = auto_modes | lookup["HOV3"]
             elif link["@hov"] == 4:
-                auto_modes =  lookup["TOLL"][link[truck]]
+                # adding 's' so that non-transponder SOVs can use toll roads by paying cash
+                auto_modes =  lookup["TOLL"][link[truck]] + set([network.mode(m_id) for m_id in "s"])
             link.modes = link.transit_modes | auto_modes
 
     def create_road_base(self, network, attr_map):

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -575,11 +575,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 # managed lanes, free for HOV2 and HOV3+, tolls for SOV
                 if link[toll] > 0:
                     auto_modes =  lookup["TOLL"][link[truck]]
-                # special case of I-15 managed lanes base year and 2020, no build
-                elif link.type == 1 and link["@project_code"] in [41, 42, 486, 373, 711]:
-                    auto_modes =  lookup["TOLL"][link[truck]]
-                elif link.type == 8 or link.type == 9:
-                    auto_modes =  lookup["TOLL"][link[truck]]
                 if link["@hov"] == 2:
                     auto_modes = auto_modes | lookup["HOV2"]
                 else:

--- a/src/main/emme/toolbox/import/import_network.py
+++ b/src/main/emme/toolbox/import/import_network.py
@@ -575,8 +575,6 @@ class ImportNetwork(_m.Tool(), gen_utils.Snapshot):
                 # managed lanes, free for HOV2 and HOV3+, tolls for SOV
                 if link[toll] > 0:
                     auto_modes =  lookup["TOLL"][link[truck]]
-                elif link.type == 8 or link.type == 9:
-                    auto_modes =  lookup["TOLL"][link[truck]]
                 if link["@hov"] == 2:
                     auto_modes = auto_modes | lookup["HOV2"]
                 else:


### PR DESCRIPTION
## Proposed changes

This pull request updates the way Emme establishes link mode availability. It had previously been handled across both the import network and traffic assignment steps, however it is cleaner and clearer to entirely handle it within the import network step. 

The pull request additionally removes hard-coded project values related to I-15 managed lanes, which had initially been incorporated into the import network step to account for base (then 2016) scenario calibrations. 

## Impact

The changes from the pull request result in expected link availability coding and also makes the code logic easier to follow given it no longer spans across more than one script. 

A few examples of link mode availability coding with the change in place and with access links coded as HOV 1:

1. This section shows the north facing H Street ramps along the Tolled (at ramps) SR-125:

<img width="1127" height="918" alt="image" src="https://github.com/user-attachments/assets/d26e06c2-3e88-4f32-bb06-1c937647ba04" />

2. This section shows mainline gp, hot, and hot access links along the I-805 just north of H Street:
<img width="1193" height="1321" alt="image" src="https://github.com/user-attachments/assets/7e16738f-ee6a-4510-9a95-451006f29e86" />

3. This section shows mainline gp, ml, and ml access links along the I-15 just north of SR-163:
<img width="690" height="1343" alt="image" src="https://github.com/user-attachments/assets/22b09843-5e9a-4213-9bc4-772fae31e6f6" />

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran a scenario with the import_network.py and traffic_assignment.py code updates in place. Additionally, the local input network was updated to change ml / hov access links to a value of HOV 1. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

@bhargavasana & @zouyang401 I had initially omitted the handling of hov 2,3 links of fc type 8,9 (ramps, freeway access links), but decided to add it back in. I am referring to [lines 581 and 582 of the import_network.py](https://github.com/SANDAG/ABM/compare/main...issue_323_mode_availability?expand=1#diff-66d2c72280618a0dacd242b387816038ec6c1a9a915e978355a588e1fcf41345L581-L582) script. My initial thoughts for removing was that all ml / hov access links would be coded as hov 1 and the traffic assignment would handle invalidating paths depending on vehicle type, but I am thinking that leaving that section of code in would give us some flexibility in the event we do code those links as hov 2,3 (and no toll value). 

I laid out some cases with and without that section of code in place to try and trace what would happen across a few different situations here:
**T:\STORAGE-63T\2025RP_draft\sr125_toll_study\2032NB_Toll_sovNtTest\modes_handling.xlsx**

**7.22.2025 Edit**: After discussing, was decided it is best to omit the exception to how the import network script handles HOV 2 and 3 links that are of FC types 8 or 9.