### PR TITLE
Clarification of density definitions in the documentation

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -161,15 +161,15 @@ The table below contains brief descriptions of the input files required to execu
 | MicroAccessTime | Micro-mobility access time (mins) | 
 | microtransit | microtransit access time (mins) | 
 | nev | Neighborhood Electric Vehicle access time (mins) | 
-| totint | Total intersections | 
-| duden | Dwelling unit density | 
-| empden | Employment density | 
-| popden | Population density | 
-| retempden | Retail employment density | 
+| totint | Total intersections within 0.65 miles of the MGRA | 
+| duden | Dwelling units per acre within 0.65 miles of the MGRA | 
+| empden | Jobs per acre within 0.65 miles of the MGRA | 
+| popden | Population per acre within 0.65 miles of the MGRA | 
+| retempden | Retail jobs per acre within 0.65 miles of the MGRA | 
 | totintbin | Total intersection bin | 
 | empdenbin | Employment density bin | 
 | dudenbin | Dwelling unit density bin | 
-| PopEmpDenPerMi | Population and employment density per mile |
+| PopEmpDenPerMi | Population and employment density per mile within 0.65 miles of the MGRA |
 
 
 ## Synthetic Population


### PR DESCRIPTION
## Proposed changes

The density fields that are added to the MGRA file at the start of the model run are not the density values for the MGRAs. Rather, they are the [density of an area within 0.65 miles of the MGRA](https://github.com/SANDAG/ABM/blob/main/src/main/emme/toolbox/import/run4Ds.py#L263-L287). This led to some confusion among SANDAG staff as there are MGRAs with no population that have a population density greater than zero. This pull request updates the documentation to clarify how the density fields are actually defined.

## Impact

The definitions of the density fields in the documentation will be clearer.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Viewed in "preview" mode in GitHub's markdown editor

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings