### PR TITLE
correct the typo in output final_persons file

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -5371,7 +5371,7 @@ This directory contains San Diego resident travel model outputs.
   <tr>
    <td>school_zone_id
    </td>
-   <td>MGRA number of school location, else -9  (output from School Location Choice Model)
+   <td>MGRA number of school location, else -1  (output from School Location Choice Model)
    </td>
   </tr>
   <tr>
@@ -5401,7 +5401,7 @@ This directory contains San Diego resident travel model outputs.
   <tr>
    <td>workplace_zone_id
    </td>
-   <td>MGRA number of internal work location, else -9  (output from Internal Work Location Choice Model)
+   <td>MGRA number of internal work location, else -1  (output from Internal Work Location Choice Model)
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Proposed changes

To correct the typo in descriptions for fields "school_zone_id", "workplace_zone_id" in final_persons.csv from resident model output.

## Impact

No impact to model results.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Confirmed the change by building the documentation website locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

