### PR TITLE
Replace logical and with multiplication in ebike utility calculation in mode choice spec files

### DIFF
--- a/src/asim/configs/resident/tour_mode_choice.csv
+++ b/src/asim/configs/resident/tour_mode_choice.csv
@@ -387,8 +387,8 @@ util_micromobility_long_trip,Shut off ebike if distance > threshold,ebikeMaxDist
 util_micromobility_long_trip,Shut off escooter if distance > threshold,escooterMaxDistance,,,,,,,,,,,,,,,,,,,,,,,-999
 util_ebike_ivt,Ebike utility for in-vehicle time,@(df.ebike_time_inb + df.ebike_time_out)*df.time_factor,,,,,,,,,,,,,,,,,,,,,,coef_ivt,
 util_ebike_access,Ebike utility for access/egress time,"@(np.where(df.ebike_owner, 0, microRentTime + df.micro_access_inb + df.micro_access_out))*df.time_factor",,,,,,,,,,,,,,,,,,,,,,coef_acctime,
-util_ebike_cost_inb,Ebike utility for inbound cost,@((~df.ebike_owner)&((microFixedCost + microVarCost*df.ebike_time_inb)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
-util_ebike_cost_out,Ebike utility for outbound cost,@((~df.ebike_owner)&((microFixedCost + microVarCost*df.ebike_time_out)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
+util_ebike_cost_inb,Ebike utility for inbound cost,@((~df.ebike_owner)*((microFixedCost + microVarCost*df.ebike_time_inb)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
+util_ebike_cost_out,Ebike utility for outbound cost,@((~df.ebike_owner)*((microFixedCost + microVarCost*df.ebike_time_out)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
 util_escooter_ivt,escooter utility for in-vehicle time,@(df.escooter_time_inb + df.escooter_time_out)*df.time_factor,,,,,,,,,,,,,,,,,,,,,,,coef_ivt
 util_escooter_access,escooter utility for in-vehicle time,@(microRentTime + df.micro_access_inb + df.micro_access_out)*df.time_factor,,,,,,,,,,,,,,,,,,,,,,,coef_acctime
 util_escooter_cost_inb,escooter utility for inbound cost,@((microFixedCost + microVarCost*df.escooter_time_inb)/df.cost_sensitivity),,,,,,,,,,,,,,,,,,,,,,,coef_income

--- a/src/asim/configs/resident/trip_mode_choice.csv
+++ b/src/asim/configs/resident/trip_mode_choice.csv
@@ -493,8 +493,8 @@ util_escooter_long_access_microTour,Decrease escooter if access time > threshold
 #util_micromobility_long_trip,Shut off ebike if distance > threshold,ebikeMaxDistance,,,,,,,,,,,,,,,,,,,,,,-999,
 #util_micromobility_long_trip,Shut off escooter if distance > threshold,escooterMaxDistance,,,,,,,,,,,,,,,,,,,,,,,-999
 util_ebike_ivt,Ebike utility for in-vehicle time,@(df.ebike_time * df.time_factor),,,,,,,,,,,,,,,,,,,,,,coef_ivt,
-util_ebike_access,Ebike utility for access time time,@((((~df.ebike_owner) | (~df.tourEbike))&(microRentTime + df.MicroAccessTime)))*df.time_factor,,,,,,,,,,,,,,,,,,,,,,coef_acctime,
-util_ebike_cost_inb,Ebike utility for inbound cost,@(((~df.ebike_owner) | (~df.tourEbike)) & ((microFixedCost + microVarCost*df.ebike_time)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
+util_ebike_access,Ebike utility for access time time,@((((~df.ebike_owner) | (~df.tourEbike))*(microRentTime + df.MicroAccessTime)))*df.time_factor,,,,,,,,,,,,,,,,,,,,,,coef_acctime,
+util_ebike_cost_inb,Ebike utility for inbound cost,@(((~df.ebike_owner) | (~df.tourEbike)) * ((microFixedCost + microVarCost*df.ebike_time)/df.cost_sensitivity)),,,,,,,,,,,,,,,,,,,,,,coef_income,
 util_escooter_ivt,Escooter utility for in-vehicle time,@(df.escooter_time)*df.time_factor,,,,,,,,,,,,,,,,,,,,,,,coef_ivt
 util_escooter_access,Escooter utility for access time,@(microRentTime + df.MicroAccessTime) *df.time_factor,,,,,,,,,,,,,,,,,,,,,,,coef_acctime
 util_escooter_cost_inb,Escooter utility for inbound cost,@(microFixedCost + microVarCost*df.escooter_time)/df.cost_sensitivity,,,,,,,,,,,,,,,,,,,,,,,coef_income


### PR DESCRIPTION
## Proposed changes

This pull request replaces logical ands with multiplication operators in a couple lines in both the tour and trip mode choice specification files. The expressions should multiply the Boolean variable of not being an ebike owner by the rental time and cost, but by using the logical and they'll return a value of 1 regardless of what the time or cost is.

This fixes issue #207.

## Impact

This will likely decrease the trips that choose e-bike as their mode. The extent of which is not yet known and further recalibration may need to be done.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Resident model was run with cropped data.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
