### PR TITLE
Recalibrate shared ebike, adjust transit onboard

### DIFF
--- a/src/asim/configs/resident/tour_mode_choice_coefficients.csv
+++ b/src/asim/configs/resident/tour_mode_choice_coefficients.csv
@@ -756,9 +756,9 @@ coef_calib_autosufficienthhin_ESCOOTER_school,-6.2720071731557105,F
 coef_calib_autosufficienthhin_EBIKE_school,-2.9282323636347396,F
 coef_calib_autosufficienthhin_ESCOOTER_atwork,-10.912007173155711,F
 coef_calib_autosufficienthhin_EBIKE_atwork,-5.877228265020214,F
-coef_calib_onboard,-0.24,F
+coef_calib_onboard,-0.26,F
 coef_calib_mt_zeroautohh,4.825,F
 coef_calib_nev_zeroautohh,4.825,F
 coef_calib_ebike_owner_BIKE,-1.407,F
 coef_calib_ebike_owner_EBIKE,0.942,F
-coef_calib_ebike_shared,-4.139014765889209,F
+coef_calib_ebike_shared,-2.2207287294883713,F


### PR DESCRIPTION
## Proposed changes

Adjusted shared ebike calibration given fix in #359. Target is shared ebike 0.25% of bike-adjacent tours, see #258. Also adjusted transit onboard coefficient due to increase in transit boardings in 15.3.1 (not fully tested)

## Impact

Increase in shared ebike micromobility trips, decrease in transit trips

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Shared ebike was calibrated using resident model tour_mode_choice, full household sample

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings