### PR TITLE
Documentation: correct fields definitions in land use file

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -159,8 +159,8 @@ The table below contains brief descriptions of the input files required to execu
 | remoteAVParking | Remote AV parking available at MGRA: 0 = Not available, 1 = Available | 
 | refueling_stations | Number of refueling stations at MGRA | 
 | MicroAccessTime | Micro-mobility access time (mins) | 
-| microtransit | microtransit access time (mins) | 
-| nev | Neighborhood Electric Vehicle access time (mins) | 
+| microtransit | The microtransit service area ID [0 means no service] | 
+| nev | Neighborhood Electric Vehicle (NEV) service area ID [0 means no service]| 
 | totint | Total intersections within 0.65 miles of the MGRA | 
 | duden | Dwelling units per acre within 0.65 miles of the MGRA | 
 | empden | Jobs per acre within 0.65 miles of the MGRA | 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -158,7 +158,7 @@ The table below contains brief descriptions of the input files required to execu
 | hch_dist | High school district | 
 | remoteAVParking | Remote AV parking available at MGRA: 0 = Not available, 1 = Available | 
 | refueling_stations | Number of refueling stations at MGRA | 
-| MicroAccessTime | Micro-mobility access time (mins) | 
+| MicroAccessTime | Shared Micro-mobility (e-scooter/e-bike) access time (mins) | 
 | microtransit | The microtransit service area ID [0 means no service] | 
 | nev | Neighborhood Electric Vehicle (NEV) service area ID [0 means no service]| 
 | totint | Total intersections within 0.65 miles of the MGRA | 


### PR DESCRIPTION
## Proposed changes

We identified errors in the data dictionary for the "microtransit" and "nev" columns. Their definitions have been corrected to represent the microtransit service area ID and the NEV service area ID, respectively.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [X] Tested the change in local view

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
