### PR TITLE
Improve DOS copy for data exporter

### DIFF
--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -320,29 +320,23 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
         # windows xcopy is much faster than shutil
         # upgrading xcopy to a faster robocopy
         self._report.append(_time.strftime("%c"))
-        exclude_filename = "TEMP_file_manager_exclude.txt"
-        exclude_file = open(exclude_filename, "a+")
-        for x in file_masks + [exclude_filename]:
-            exclude_file.write(x + '\n')
-        exclude_file.close()
         # if check_metadata:
         #     flags = '/Y/S/E/D'
         # else:
         #     flags = '/Y/S/E'
         try:
-            exclude_file_list = file_masks + [exclude_filename]
+            exclude_file_list = file_masks
             flags = ['/E', '/Z', '/MT:8']
             output = _subprocess.check_output(['robocopy', src, dst] + flags + ["/XF"] + exclude_file_list + ["/XD"] + exclude_file_list)
             self._report.append(output)
+            self._report.append(_time.strftime("%c"))
         except _subprocess.CalledProcessError as error:
             self._report.append(error.output)
             self.log_report()
-            if (error.returncode < 16) and (error.returncode > 0):
-                self._report.append(error.output)
-            else:
+            self._report.append(_time.strftime("%c"))
+            if error.returncode >= 8:
                 raise
-        os.remove(exclude_filename)
-        self._report.append(_time.strftime("%c"))
+        
 
         # for name in os.listdir(src):
         #     src_path = _join(src, name)


### PR DESCRIPTION
## Proposed changes

Based on issue https://github.com/SANDAG/ABM/issues/374. Copying model data from C: drive back to T: drive has been taking longer and occasionally failing. This PR modifies the script to improve copy speed of all non-EMME specific files and prioritizes copy of all non-EMME specific files over EMME files and directories.

## Impact

Replaces `xcopy` DOS command with `robocopy` (with a copy speed of ~7,500 MegaBytes/min).

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran a partial 2050 run with data export step included.
- [x] Ran full 2022 run with all steps.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Further comments

The new copy method has different error codes when compared to the previous method. A return code other than 0 or 1 is not an immediate flag and is coded to not raise an error but should be examined. Error code 16 (no files were copied over) will be raised.
