### PR TITLE
Fix build without git

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -80,7 +80,7 @@ set GIT_FOLDER=.\.git
 set GIT_FILE=%ROOT%\common\git_info.yaml
 type nul>%GIT_FILE%
 WHERE git
-IF NOT ERRORLEVEL 0 GOTO NOGIT
+IF NOT %ERRORLEVEL% == 0 GOTO NOGIT
 echo|set /p="branch: " >> %GIT_FILE%
 git --git-dir=%GIT_FOLDER% branch --show-current >> %GIT_FILE%
 echo|set /p="commit: " >> %GIT_FILE%


### PR DESCRIPTION
## Proposed changes

The build script populates git_info.yaml with the git branch and commit id used to build the release. This was not working if git was not installed, generating empty fields in this file. This PR fixes the part of the script that handles the case where git is not installed.

Batch allows "IF ERRORLEVEL 0" as a shortcut to check error code, but apparently does not allow "IF NOT ERRORLEVEL 0". This fix replaces the invalid shortcut with the full line "IF NOT %ERRORLEVEL% == 0"

## Impact

git_info.yaml will be correctly populated regardless of whether git is installed, avoiding a potential crash when this file is used in update_tables

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Tested on laptop without git installed that previously encountered the issue, confirmed file was populated correctly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
