### PR TITLE
update the employment multiplier for different airport MGRAs

### DIFF
--- a/src/asim/scripts/resident/resident_preprocessing.py
+++ b/src/asim/scripts/resident/resident_preprocessing.py
@@ -49,24 +49,37 @@ class Series15_Processor:
         abm3_settings_file = os.path.join(project_dir, 'conf', 'abm3_settings.yaml')
         abm3_settings = util.open_yaml(abm3_settings_file)
         sdia_config = abm3_settings['airport']['san']['sdiaEmploymentMultiplier']
-        self.sdia_mgras = sdia_config['mgras']
-        multiplier_by_year = sdia_config['multiplierByYear']
         
-        # Get multiplier for the scenario year, using the closest available year
-        available_years = sorted([int(y) for y in multiplier_by_year.keys()])
+        # Load configurations for airport_north and airport_south
         year_int = int(self.scenario_year)
+        self.sdia_configs = []
         
-        # Find the appropriate multiplier: use exact match or closest lower year
-        self.sdia_employment_multiplier = None
-        for year in available_years:
-            if year <= year_int:
-                self.sdia_employment_multiplier = multiplier_by_year[str(year)]
-            else:
-                break
-        
-        # If scenario year is before all configured years, use the first year's multiplier
-        if self.sdia_employment_multiplier is None:
-            self.sdia_employment_multiplier = multiplier_by_year[str(available_years[0])]
+        for location_name in ['airport_north', 'airport_south']:
+            if location_name in sdia_config:
+                location_config = sdia_config[location_name]
+                mgras = location_config['mgras']
+                multiplier_by_year = location_config['multiplierByYear']
+                
+                # Get multiplier for the scenario year, using the closest available year
+                available_years = sorted([int(y) for y in multiplier_by_year.keys()])
+                
+                # Find the appropriate multiplier: use exact match or closest lower year
+                multiplier = None
+                for year in available_years:
+                    if year <= year_int:
+                        multiplier = multiplier_by_year[str(year)]
+                    else:
+                        break
+                
+                # If scenario year is before all configured years, use the first year's multiplier
+                if multiplier is None:
+                    multiplier = multiplier_by_year[str(available_years[0])]
+                
+                self.sdia_configs.append({
+                    'location': location_name,
+                    'mgras': mgras,
+                    'multiplier': multiplier
+                })
     
         if int(scenario_year) < 2026:
             self.ext_station_to_internal_mapping = {1:9279, 2:9387, 4:22324}
@@ -149,8 +162,14 @@ class Series15_Processor:
         emp_cols = [col for col in landuse.columns if col.startswith('emp_')]
         # Convert employment columns to float to handle multiplier operations
         landuse[emp_cols] = landuse[emp_cols].astype(float)
-        landuse.loc[landuse['mgra'].isin(self.sdia_mgras), emp_cols] *= self.sdia_employment_multiplier
-        print(f"Applied SDIA employment multiplier of {self.sdia_employment_multiplier} to {len(self.sdia_mgras)} MGRAs for year {self.scenario_year}")
+        
+        # Apply multipliers for each configured location (airport_north, airport_south)
+        for config in self.sdia_configs:
+            location = config['location']
+            mgras = config['mgras']
+            multiplier = config['multiplier']
+            landuse.loc[landuse['mgra'].isin(mgras), emp_cols] *= multiplier
+            print(f"Applied SDIA employment multiplier of {multiplier} to {len(mgras)} MGRAs for {location} for year {self.scenario_year}")
 
         # setting MAZ as index
         landuse.set_index('MAZ', inplace=True)

--- a/src/main/resources/abm3_settings.yaml
+++ b/src/main/resources/abm3_settings.yaml
@@ -236,18 +236,18 @@ airport:
     # SDIA employment multiplier configuration
     # Applied to specific MGRAs at San Diego International Airport
     sdiaEmploymentMultiplier:
-      mgras: [11249, 8455, 1306, 11244, 11247, 8745, 11248, 9080, 11246, 11250]
-      multiplierByYear:
-        "2022": 2.5
-        "2025": 2.5
-        "2026": 2.5
-        "2029": 2.5
-        "2030": 2.5
-        "2032": 2.5
-        "2035": 2.5
-        "2040": 2.5
-        "2045": 2.5
-        "2050": 2.5
+      airport_north:
+        mgras: [11244]
+        multiplierByYear:
+          "2022": 2.5
+          "2035": 2.5
+          "2050": 2.5
+      airport_south:
+        mgras: [11248, 11249]
+        multiplierByYear:
+          "2022": 3.0
+          "2035": 3.0
+          "2050": 3.0
 
     accessOptions:
       park:


### PR DESCRIPTION
## Proposed changes

This PR implements a configurable employment multiplier for San Diego International Airport (SDIA) MGRAs to adjust employment counts during resident preprocessing based on the scenario year.

- 3.0 to south_airport: [11248, 11249]
- 2.5 to north_airport: [11244]

## Impact

<img width="333" height="106" alt="image" src="https://github.com/user-attachments/assets/ec4ce476-5686-4f1b-8359-cac30799d32a" />

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Tested and the airport employment increased from 1,374 to 3,700

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
