### PR TITLE
SAN airport employee multiplier and free parking update

### DIFF
--- a/src/asim/configs/resident/free_parking.csv
+++ b/src/asim/configs/resident/free_parking.csv
@@ -1,4 +1,5 @@
 Label,Description,Expression,free,pay
+util_airport_zones,Airport employment zones with high free parking,"@df.workplace_zone_id.isin([11244,11248,11249])",coef_airport_zones,0.0
 util_income_very_high,Very high income household dummy,@df.income>=100000,coef_income_very_high,0.0
 util_income_high,High income housheold dummy,@(df.income>=60000) & (df.income<100000),coef_income_high,0.0
 util_hh_size_4_up,Household size is greater than 3 dummy,@df.hhsize>3,coef_hh_size_4_up,0.0

--- a/src/asim/configs/resident/free_parking_coefficients.csv
+++ b/src/asim/configs/resident/free_parking_coefficients.csv
@@ -1,4 +1,5 @@
 coefficient_name,value,constrain
+coef_airport_zones,2.2,F
 coef_asc_san_francisco,-2.6403,F
 coef_asc_santa_clara,0.2118,F
 coef_asc_alameda,-0.1092,F

--- a/src/main/resources/abm3_settings.yaml
+++ b/src/main/resources/abm3_settings.yaml
@@ -280,19 +280,12 @@ airport:
           walkTime: 2.00
           waitTime: 3.00
         loc5:
-          mgra: 1306
-          accessCost: 0.00
-          dailyCost: 25.62
-          inVehicleTime: 6.00
-          walkTime: 2.00
-          waitTime: 3.00
-      parkEscort:
-        mgra: *sanTerminalMGRA
-        accessCost: 0.00
-        hourlyCost: 7.32
-        inVehicleTime: 0.00
-        walkTime: 5.00
-        waitTime: 0.00
+          mgra: -999
+          accessCost: 0
+          dailyCost: 0
+          inVehicleTime: -999
+          walkTime: -999
+          waitTime: -999
       rental:
         mgra: 11244
         accessCost: 0.00

--- a/src/main/resources/abm3_settings.yaml
+++ b/src/main/resources/abm3_settings.yaml
@@ -239,9 +239,9 @@ airport:
       airport_north:
         mgras: [11244]
         multiplierByYear:
-          "2022": 2.5
-          "2035": 2.5
-          "2050": 2.5
+          "2022": 1.8
+          "2035": 1.8
+          "2050": 1.8
       airport_south:
         mgras: [11248, 11249]
         multiplierByYear:


### PR DESCRIPTION
## Proposed changes

This PR implements differentiated employment multipliers for San Diego International Airport (SDIA) zones and adds support for airport zone-specific free parking modeling.

## Impact

1.  Employment Multiplier Refinement
  - Replaced single global employment multiplier for SDIA with location-specific multipliers
  - Split airport zones into two categories:
    - Airport North (MGRA 11244): Multiplier = 1.8
    - Airport South (MGRAs 11248, 11249): Multiplier = 3.0
2. Free Parking Model Enhancements
  - Added new utility term for airport employment zones (11244, 11248, 11249)
  - free parking share in airport is 89% 
3. Airport Access Options Cleanup
  - Removed parking location 5 (MGRA 1306) - set to inactive with -999 values
  - Removed parkEscort access option from SAN airport model configuration

<img width="1575" height="260" alt="image" src="https://github.com/user-attachments/assets/81a43588-0e86-4c38-a10f-123e82086d06" />
<img width="344" height="98" alt="image" src="https://github.com/user-attachments/assets/461ac4cc-684a-4758-9975-93e6a12fd148" />

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Tested full sample iteration for resident model and airport model
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

