### PR TITLE
removing related parkEscort settings in SAN airport model

### DIFF
--- a/src/asim/configs/airport.SAN/trip_mode_choice.yaml
+++ b/src/asim/configs/airport.SAN/trip_mode_choice.yaml
@@ -59,7 +59,6 @@ CONSTANTS:
   parkLocation3Mgra: {airport-san-accessOptions-park-loc3-mgra:}
   parkLocation4Mgra: {airport-san-accessOptions-park-loc4-mgra:}
   parkLocation5Mgra: {airport-san-accessOptions-park-loc5-mgra:}
-  parkEscortLocationMgra: {airport-san-accessOptions-parkEscort-mgra:}
   rentalLocationMgra: {airport-san-accessOptions-rental-mgra:}
   centralMobilityHubMgra: {airport-san-centralMobilityHubMGRA:}
   ridehailLocation1Mgra: {airport-san-accessOptions-ridehail-loc1-mgra:}
@@ -98,11 +97,6 @@ CONSTANTS:
   parkLocation5InVehicleTime: {airport-san-accessOptions-park-loc5-inVehicleTime:}
   parkLocation5WalkTime: {airport-san-accessOptions-park-loc5-walkTime:}
   parkLocation5WaitTime: {airport-san-accessOptions-park-loc5-waitTime:}
-  parkEscortAccessCost: {airport-san-accessOptions-parkEscort-accessCost:}
-  parkEscortCostHour: {airport-san-accessOptions-parkEscort-hourlyCost:}
-  parkEscortInVehicleTime: {airport-san-accessOptions-parkEscort-inVehicleTime:}
-  parkEscortWalkTime: {airport-san-accessOptions-parkEscort-walkTime:}
-  parkEscortWaitTime: {airport-san-accessOptions-parkEscort-waitTime:}
   rentalCarAccessCost: {airport-san-accessOptions-rental-accessCost:}
   rentalCostPerDay: {airport-san-accessOptions-rental-dailyCost:}
   rentalCarInVehicleTime: {airport-san-accessOptions-rental-inVehicleTime:}

--- a/src/asim/configs/airport.SAN/write_trip_matrices_annotate_trips_preprocessor.csv
+++ b/src/asim/configs/airport.SAN/write_trip_matrices_annotate_trips_preprocessor.csv
@@ -11,7 +11,7 @@ Description,Target,Expression
 ,_trip_mode," np.where(trips.rental_car_choice == 1, 'RENTAL', _trip_mode)"
 ,_trip_mode,"pd.Series(_trip_mode, index=df.index)"
 ,_sample_rate,trips.household_id.map(households.sample_rate)
-,add_driver," (_trip_mode.isin(['PARK_ESCORT','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & ( tour_participants == 1) & (trips['trip_num'] ==1)) | (_trip_mode.isin(['PARK_ESCORT','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & (tour_participants >=2) & (trips.trip_num == 1))"
+,add_driver," (_trip_mode.isin(['CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & ( tour_participants == 1) & (trips['trip_num'] ==1)) | (_trip_mode.isin(['CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & (tour_participants >=2) & (trips.trip_num == 1))"
 ,_participants_add_driver,"np.where(add_driver, tour_participants + 1, tour_participants )"
 ,weightTrip,1/_sample_rate
 ,weightPersonTrip,"_participants_add_driver/_sample_rate"
@@ -21,9 +21,9 @@ Description,Target,Expression
 ,is_md,"trips.depart.between(time_periods['MD']['first_hour'], time_periods['MD']['last_hour'])"
 ,is_pm,"trips.depart.between(time_periods['PM']['first_hour'], time_periods['PM']['last_hour'])"
 ,is_ev,"trips.depart.between(time_periods['EV']['first_hour'], time_periods['EV']['last_hour'])"
-,is_drivealone," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL']) &  (tour_participants ==1)) | (_trip_mode.isin(['PARK_ESCORT','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5']) & (trips.trip_num == 2))"
-,is_shared2," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL']) & ( tour_participants ==2)) | (_trip_mode.isin(['RIDEHAIL_LOC1','RIDEHAIL_LOC2','TAXI_LOC1','TAXI_LOC2','PARK_ESCORT','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & ( tour_participants == 1) & (trips['trip_num'] ==1))"
-,is_shared3," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL', 'HOTEL_COURTESY', 'SHUTTLEVAN']) &  (tour_participants >= 3)) | (_trip_mode.isin(['RIDEHAIL_LOC1','RIDEHAIL_LOC2','TAXI_LOC1','TAXI_LOC2','PARK_ESCORT','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5', 'HOTEL_COURTESY', 'SHUTTLEVAN'])  & (tour_participants >=2) & (trips.trip_num == 1))"
+,is_drivealone," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL']) &  (tour_participants ==1)) | (_trip_mode.isin(['CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5']) & (trips.trip_num == 2))"
+,is_shared2," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL']) & ( tour_participants ==2)) | (_trip_mode.isin(['RIDEHAIL_LOC1','RIDEHAIL_LOC2','TAXI_LOC1','TAXI_LOC2','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5'])  & ( tour_participants == 1) & (trips['trip_num'] ==1))"
+,is_shared3," (_trip_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','RENTAL', 'HOTEL_COURTESY', 'SHUTTLEVAN']) &  (tour_participants >= 3)) | (_trip_mode.isin(['RIDEHAIL_LOC1','RIDEHAIL_LOC2','TAXI_LOC1','TAXI_LOC2','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','CURB_LOC5', 'HOTEL_COURTESY', 'SHUTTLEVAN'])  & (tour_participants >=2) & (trips.trip_num == 1))"
 ,is_walk,_trip_mode == 'WALK'
 ,is_walk_LOC_transit,_trip_mode == 'WALK_LOC'
 ,is_walk_PRM_transit,_trip_mode == 'WALK_PRM'
@@ -234,10 +234,10 @@ Description,Target,Expression
 ,_costTollDrive,"_costTollDrive + odt_skims['SOV_NT_H_TOLLCOST'] * np.where(((trip_mode_assign == 'DRIVEALONE') & vot3),1,0) / _participants_add_driver"
 ,_costTollDrive,"_costTollDrive + odt_skims['HOV2_H_TOLLCOST'] * np.where(((trip_mode_assign == 'SHARED2') & vot3),1,0) / _participants_add_driver"
 ,_costTollDrive,"_costTollDrive + odt_skims['HOV3_H_TOLLCOST'] * np.where(((trip_mode_assign == 'SHARED3') & vot3),1,0) / _participants_add_driver"
-,costTollDrive,"np.where(arrival_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','PARK_ESCORT','SHUTTLEVAN','HOTEL_COURTESY','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','RENTAL']),_costTollDrive,0)"
+,costTollDrive,"np.where(arrival_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','SHUTTLEVAN','HOTEL_COURTESY','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','RENTAL']),_costTollDrive,0)"
 #,,
 ,_costOperatingDrive,0
-,_costOperatingDrive,"_costOperatingDrive + arrival_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','PARK_ESCORT','SHUTTLEVAN','HOTEL_COURTESY','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','RENTAL']) * distanceDrive * costPerMile / _participants_add_driver"
+,_costOperatingDrive,"_costOperatingDrive + arrival_mode.isin(['PARK_LOC1','PARK_LOC2','PARK_LOC3','PARK_LOC4','PARK_LOC5','SHUTTLEVAN','HOTEL_COURTESY','CURB_LOC1','CURB_LOC2','CURB_LOC3','CURB_LOC4','RENTAL']) * distanceDrive * costPerMile / _participants_add_driver"
 ,costOperatingDrive,"_costOperatingDrive + arrival_mode.isin(['KNR_LOC','KNR_PRM','KNR_MIX']) * (df.time_transit_drive/60) * driveSpeed * costPerMile / _participants_add_driver"
 #,,
 ,cost_parking,"np.where(trips['trip_num'] == 1, trips.cost_parking, 0)"


### PR DESCRIPTION
## Proposed changes

To clean up all parkEscort references from the SAN airport configuration. Here's what was removed:

From [trip_mode_choice.yaml]:
- Removed parkEscortLocationMgra constant
- Removed 5 parkEscort cost/time constants: parkEscortAccessCost, parkEscortCostHour, parkEscortInVehicleTime, parkEscortWalkTime, parkEscortWaitTime

From [write_trip_matrices_annotate_trips_preprocessor.csv]:
- Removed 'PARK_ESCORT' from the add_driver expression
- Removed 'PARK_ESCORT' from the is_drivealone expression
- Removed 'PARK_ESCORT' from the is_shared2 expression
- Removed 'PARK_ESCORT' from the is_shared3 expression
- Removed 'PARK_ESCORT' from the costTollDrive expression
- Removed 'PARK_ESCORT' from the _costOperatingDrive expression

## Impact
NA

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [z] My changes generate no new warnings

