### PR TITLE
Update conditions for overwriting local files

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -331,9 +331,9 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
             folder_name = os.path.basename(main_directory)
             if not os.path.exists(_join(self.LOCAL_ROOT, username, folder_name, "report")): # check free space only if it is a new run
                 self.check_free_space(minSpaceOnC)
-            # if initialization copy ALL files from remote
+            # if initialization (both MGRA Skims and 4Ds are run) copy ALL files from remote
             # else check file meta data and copy those that have changed
-            initialize = (skipInitialization == False and startFromIteration == 1)
+            initialize = (skipMGRASkims == False and skip4Ds == False and startFromIteration == 1)
             local_directory = file_manager(
                 "DOWNLOAD", main_directory, username, scenario_id, initialize=initialize)
             self._path = local_directory


### PR DESCRIPTION
## Proposed changes

Files on local drive should only be fully overwritten when starting a run from beginning (otherwise should compare timestamp). Previously it was assumed that if "skipInitialization" is false, the run is starting from the beginning. However, this option is actually "Skip matrix and transit database initialization", which is not the first step of the run, meaning if prior steps were skipped the scenario would still overwrite files on local drive. This PR updates this to instead check that both "skipMGRASkims" and "skip4Ds" are false, assuming that the run is starting from beginning if both MGRA Skims and 4Ds are run.

## Impact

Avoids overwriting local files when re-running early steps. For example, a recent scenario prior to this fix re-ran build network while skipping 4Ds, but the generated 4Ds files were overwritten on local drive. 

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] Untested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
