### PR TITLE
Remove unused bike skims in 2zoneSkim

### DIFF
--- a/src/asim/scripts/resident/2zoneSkim.py
+++ b/src/asim/scripts/resident/2zoneSkim.py
@@ -13,7 +13,6 @@ import logging
 class SkimParameters:
     """Configuration parameters for skim generation read from YAML file"""
     max_maz_maz_walk_dist_feet: int
-    max_maz_maz_bike_dist_feet: int
     max_maz_local_bus_stop_walk_dist_feet: int
     max_maz_premium_transit_stop_walk_dist_feet: int
     walk_speed_mph: float
@@ -25,7 +24,6 @@ class SkimParameters:
         mmms = yaml_data['mmms']
         return cls(
             max_maz_maz_walk_dist_feet=int(mmms['max_maz_maz_walk_dist_feet']),
-            max_maz_maz_bike_dist_feet=int(mmms['max_maz_maz_bike_dist_feet']),
             max_maz_local_bus_stop_walk_dist_feet=int(mmms['max_maz_local_bus_stop_walk_dist_feet']),
             max_maz_premium_transit_stop_walk_dist_feet=int(mmms['max_maz_premium_transit_stop_walk_dist_feet']),
             walk_speed_mph=float(mmms['walk_speed_mph']),
@@ -305,7 +303,7 @@ class NetworkBuilder:
         return stops
 
 class SkimGenerator:
-    """Main class for generating walk, bike, and stop skims"""
+    """Main class for generating walk and stop skims"""
     
     def __init__(self, network_builder: NetworkBuilder, params: SkimParameters, output_path: str):
         self.network_builder = network_builder
@@ -326,13 +324,6 @@ class SkimGenerator:
         walk_skim = self._add_intrazonal_distances(walk_skim)
         walk_skim = self._convert_columns_to_type(walk_skim, {'OMAZ': 'uint16', 'DMAZ': 'uint16', 'i': 'uint16', 'j': 'uint16'})
         return walk_skim
-        
-    def generate_maz_maz_bike_skim(self) -> pd.DataFrame:
-        """Generate MAZ to MAZ bike skims"""
-        maz_pairs = self._create_maz_pairs(self.net_centroids)
-        bike_skim = self._get_bike_distances(maz_pairs, self.params.max_maz_maz_bike_dist_feet)
-        bike_skim = self._convert_columns_to_type(bike_skim, {'OMAZ': 'uint16', 'DMAZ': 'uint16'})
-        return bike_skim
         
     def generate_maz_stop_walk_skim(self) -> pd.DataFrame:
         """Generate MAZ to stop walk skims"""
@@ -422,18 +413,6 @@ class SkimGenerator:
         result[['i', 'j']] = result[['OMAZ', 'DMAZ']]
         result['actual'] = result['DISTWALK'] / self.params.walk_speed_mph * 60.0
 
-        return result
-    
-    def _get_bike_distances(self, pairs: pd.DataFrame, max_dist: float) -> pd.DataFrame:
-        """Process bike distances between MAZ pairs"""
-        filtered = pairs[pairs["DISTWALK"] <= max_dist / 5280.0].copy()
-        filtered["DISTBIKE"] = self.network_builder.network.shortest_path_lengths(
-            filtered["OMAZ_NODE"].values, filtered["DMAZ_NODE"].values)
-        result = filtered[filtered["DISTBIKE"] <= max_dist / 5280.0]
-
-        # Add missing MAZs
-        result = self._add_missing_mazs(self.net_centroids, result, pairs, 'DISTBIKE')
-        
         return result
     
     def _get_stop_distances(self, pairs: pd.DataFrame) -> pd.DataFrame:
@@ -564,10 +543,6 @@ def main(path: str):
     print(f"{datetime.now().strftime('%H:%M:%S')} Generating MAZ-MAZ walk skims...")
     walk_skim = skim_generator.generate_maz_maz_walk_skim()
     walk_skim.to_csv(os.path.join(output_path, config['mmms']['maz_maz_walk_output']), index=False)
-    
-    print(f"{datetime.now().strftime('%H:%M:%S')} Generating MAZ-MAZ bike skims...")
-    bike_skim = skim_generator.generate_maz_maz_bike_skim()
-    bike_skim.to_csv(os.path.join(output_path, config['mmms']['maz_maz_bike_output']), index=False)
     
     print(f"{datetime.now().strftime('%H:%M:%S')} Generating MAZ-stop walk skims...")
     stop_skim = skim_generator.generate_maz_stop_walk_skim()


### PR DESCRIPTION
## Proposed changes

Removes code to generate bike skims in 2zoneSkim.py. These skims are unused and overwritten later in the model by the bike logsum process (or by copying from input directory if bike logsums is skipped)

[AB#2650](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/2650)

## Impact

Code cleanup

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran model throughiteration 1 resident model with no errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
