### PR TITLE
Write process run report logs

### DIFF
--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -581,7 +581,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         # Run transit assignment in separate process
                         # Running in same process slows OMX skim export for unknown reason
                         # transit_emmebank need to be closed and re-opened to be accessed by separate process
-                        transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, ((not skipTransitConnector) and (msa_iteration == 1)), main_directory)
+                        transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, ((not skipTransitConnector) and (msa_iteration == 1)), main_directory, iteration=msa_iteration)
                         for period in periods:
                             transit_scenario_dict[period] = transit_emmebank_dict[period].scenario(base_scenario.number)
                         # _m.Modeller().desktop.refresh_data()
@@ -750,7 +750,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 # Run transit assignment in separate process
                 # Running in same process slows OMX skim export for unknown reason
                 # transit_emmebank need to be closed and re-opened to be accessed by separate process
-                transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, False, main_directory)
+                transit_emmebank_dict = self.run_transit_assignments(transit_emmebank_dict, scenarioYear, output_dir, False, main_directory, iteration=4)
                 for period in periods:
                     transit_scenario_dict[period] = transit_emmebank_dict[period].scenario(base_scenario.number)
                 # _m.Modeller().desktop.refresh_data()
@@ -876,7 +876,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         except KeyError:
             raise Exception("properties.RunModel.LogLevel: value must be one of %s" % ",".join(log_states.keys()))
 
-    def run_transit_assignments(self, transit_emmebank_dict, scenarioYear, output_dir, create_connector_flag, main_directory_original):
+    def run_transit_assignments(self, transit_emmebank_dict, scenarioYear, output_dir, create_connector_flag, main_directory_original, iteration):
 
         scenario_id = 100
         periods = ["EA", "AM", "MD", "PM", "EV"]
@@ -915,16 +915,21 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 
                 _time.sleep(2)
 
+                with open(_join(self._path, 'logFiles', 'run_transit_assignment_%s_iter%d.log' % (period, iteration)), 'w') as f:
+                    f.write('Output:\n')
+                f = open(_join(self._path, 'logFiles', 'run_transit_assignment_%s_iter%d.log' % (period, iteration)), 'a+')
+
                 script = _join(main_directory, "python", "emme", "run_transit_assignment.py")
                 args = [sys.executable, script, "--root_dir", '"%s"' % main_directory, "--project_path", '"%s"' % project_path,
                     "--period", '"%s"' % period, "--number", '"%s"' % number, "--proc", '"%s"' % transit_processors,
                     "--output_dir", '"%s"' % output_dir]
                 if create_connector_flag:
                     args.append("--create_connector_flag")
-                p = _subprocess.Popen(args, shell=True)
+                p = _subprocess.Popen(args, shell=True, stdout=f, stderr=f)
                 processes.append({
                     "p": p,
-                    "period": period
+                    "period": period,
+                    "f": f
                 })
                 _time.sleep(2)
 
@@ -934,10 +939,10 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 
             for p in processes:
                 report = _m.PageBuilder(title="Command report")
-                out, err = p["p"].communicate()
-                self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % out)
-                if err:
-                    self.add_html(report, 'Error message(s):<br><br><div class="preformat">%s</div>' % err)
+                _, _ = p["p"].communicate()
+                p["f"].seek(0)
+                self.add_html(report, '<div class="preformat">%s</div>' % p["f"].read())
+                p["f"].close()
                 _m.logbook_write("Transit assignment process record for period " + p["period"], report.render())
                 if p["p"].returncode != 0:
                     raise Exception("Error in transit assignment period %s, refer to logbook in dummy project" % p["period"])

--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -915,9 +915,10 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
 
                 _time.sleep(2)
 
-                with open(_join(self._path, 'logFiles', 'run_transit_assignment_%s_iter%d.log' % (period, iteration)), 'w') as f:
+                log_path = _join(self._path, 'logFiles', 'run_transit_assignment_%s_iter%d.log' % (period, iteration))
+                with open(log_path, 'w') as f:
                     f.write('Output:\n')
-                f = open(_join(self._path, 'logFiles', 'run_transit_assignment_%s_iter%d.log' % (period, iteration)), 'a+')
+                f = open(log_path, 'a+')
 
                 script = _join(main_directory, "python", "emme", "run_transit_assignment.py")
                 args = [sys.executable, script, "--root_dir", '"%s"' % main_directory, "--project_path", '"%s"' % project_path,
@@ -991,15 +992,16 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 else:
                     command_str = str(command)
                 command_str = command_str.replace("\r\n", "<br>").replace("\n", "<br>")
-                with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'w') as f:
+                log_path = _join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix))
+                with open(log_path, 'w') as f:
                     f.write('Command:\n\n%s\n\nOutput:\n' % command_str)
                 try:
-                    with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'a') as f:
+                    with open(log_path, 'a') as f:
                         _subprocess.run(command, stdout=f, stderr=f, cwd=self._path, shell=True, check=True)
                 except _subprocess.CalledProcessError as error:
                     raise Exception("Error in %s, refer to process run report in logbook" % name)
                 finally:
-                    with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'r') as f:
+                    with open(log_path, 'r') as f:
                         self.add_html(report, '<div class="preformat">%s</div>' % f.read())
                     try:
                         # No raise on writing report error

--- a/src/main/emme/toolbox/master_run.py
+++ b/src/main/emme/toolbox/master_run.py
@@ -595,7 +595,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 if not skipSkimConversion[iteration]:
                     self.run_proc("convertSkimsToOMXZ.cmd",
                                   [drive, path_forward_slash],
-                                  "Converting skims to omxz format", capture_output=True)
+                                  "Converting skims to omxz format", capture_output=True, iteration=msa_iteration)
 
                 if not skipTransponderExport[iteration]:
                     am_scenario = main_emmebank.scenario(base_scenario.number + 2)
@@ -610,7 +610,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                     self.run_proc(
                         "runSandagAbm_Preprocessing.cmd",
                         [drive, drive + path_forward_slash, msa_iteration, scenarioYear],
-                        "Creating all the required files to run the ActivitySim models", capture_output=True)
+                        "Creating all the required files to run the ActivitySim models", capture_output=True, iteration=msa_iteration)
 
                 # skip_asim = skipABMResident[iteration] and skipABMAirport[iteration] and skipABMXborder[iteration] and skipABMVisitor[iteration]
 
@@ -627,7 +627,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         self.run_proc(
                             "runSandagAbm_ActivitySimResident.cmd",
                             [drive, drive + path_forward_slash],
-                            "Running ActivitySim resident model", capture_output=True)
+                            "Running ActivitySim resident model", capture_output=True, iteration=msa_iteration)
                     if not skipABMAirport[iteration]:
                         hh_airport_size = {}
                         for airport in ["san", "cbx"]:
@@ -639,12 +639,12 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         self.run_proc(
                             "runSandagAbm_ActivitySimAirport.cmd",
                             [drive, drive + path_forward_slash],
-                            "Running ActivitySim airport models", capture_output=True)
+                            "Running ActivitySim airport models", capture_output=True, iteration=msa_iteration)
                     if (not skipABMXborderWait) and (iteration == 0):
                         self.run_proc(
                             "runSandagAbm_ActivitySimXborderWaitModel.cmd",
                             [drive, drive + path_forward_slash],
-                            "Running ActivitySim wait time models", capture_output=True)
+                            "Running ActivitySim wait time models", capture_output=True, iteration=msa_iteration)
                     if not skipABMXborder[iteration]:
                         householdFile = pd.read_csv(_join(self._path, "input", "households_xborder.csv"))
                         hh_xborder_size = len(householdFile)
@@ -653,7 +653,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         self.run_proc(
                             "runSandagAbm_ActivitySimXborder.cmd",
                             [drive, drive + path_forward_slash],
-                            "Running ActivitySim crossborder model", capture_output=True)
+                            "Running ActivitySim crossborder model", capture_output=True, iteration=msa_iteration)
                     if not skipABMVisitor[iteration]:
                         householdFile = pd.read_csv(_join(self._path, "input", "households_visitor.csv"))
                         hh_visitor_size = len(householdFile)
@@ -662,7 +662,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         self.run_proc(
                             "runSandagAbm_ActivitySimVisitor.cmd",
                             [drive, drive + path_forward_slash],
-                            "Running ActivitySim visitor model", capture_output=True)
+                            "Running ActivitySim visitor model", capture_output=True, iteration=msa_iteration)
                 finally:
                     pass
                     # if not skip_asim:
@@ -687,17 +687,17 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                     self.run_proc(
                         "runSandagAbm_MAAS.cmd",
                         [drive, drive + path_forward_slash, 1, 0],
-                        "Java-Run AV allocation model and TNC routing model", capture_output=True)
+                        "Java-Run AV allocation model and TNC routing model", capture_output=True, iteration=msa_iteration)
 
                 if (not skipCVMEstablishmentSyn) and (iteration == 0):
                     self.run_proc("cvmEst.bat", [drive, path_no_drive, cvm_emp_input_file],
-                        "Commercial vehicle model establishment synthesis", capture_output=True)
+                        "Commercial vehicle model establishment synthesis", capture_output=True, iteration=msa_iteration)
                 if not skipCTM[iteration]:
                     #export_for_commercial_vehicle(output_dir + '/skims', base_scenario)
                     self.run_proc(
                         "cvm.bat",
                         [drive, path_no_drive, str(scenarioYear) + str(scenarioYearSuffix)],
-                        "Commercial vehicle model", capture_output=True)
+                        "Commercial vehicle model", capture_output=True, iteration=msa_iteration)
                 if msa_iteration == startFromIteration:
                     external_zones = "1-12"
                     if not skipTruck[iteration]:
@@ -705,7 +705,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                         self.run_proc(
                             "htm.bat",
                             [drive, path_no_drive, fafInputFile, htm_input_file, "PM", truck_scenario_year, str(scenarioYear) + str(scenarioYearSuffix)],
-                            "Heavy truck model", capture_output=True)
+                            "Heavy truck model", capture_output=True, iteration=msa_iteration)
                     # run EI model "US to SD External Trip Model"
                     if not skipEI[iteration]:
                         external_internal(input_dir, base_scenario)
@@ -729,7 +729,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 self.run_proc(
                         "runSandagAbm_Preprocessing.cmd",
                         [drive, drive + path_forward_slash, final_iteration, scenarioYear],
-                        "Adding DIST skim", capture_output=True)
+                        "Adding DIST skim", capture_output=True, iteration=final_iteration)
 
         if not skipFinalTransitAssignment:
             import_transit_demand(output_dir, transit_scenario_dict)
@@ -967,7 +967,7 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
             if msa_iteration <= 4:
                 export_traffic_skims(period, omx_file, base_scenario)
 
-    def run_proc(self, name, arguments, log_message, capture_output=False):
+    def run_proc(self, name, arguments, log_message, capture_output=False, iteration=-1):
         path = _join(self._path, "bin", name)
         if not os.path.exists(path):
             raise Exception("No command / batch file '%s'" % path)
@@ -975,6 +975,10 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
         attrs = {"command": command, "name": name, "arguments": arguments}
         with _m.logbook_trace(log_message, attributes=attrs):
             if capture_output and self._log_level != "NO_EXTERNAL_REPORTS":
+                if iteration == -1:
+                    name_suffix = ''
+                else:
+                    name_suffix = '_iter%d' % iteration
                 report = _m.PageBuilder(title="Process run %s" % name)
                 # Show the command being run in the report, decode if bytes
                 if isinstance(command, bytes):
@@ -982,24 +986,16 @@ class MasterRun(props_utils.PropertiesSetter, _m.Tool(), gen_utils.Snapshot):
                 else:
                     command_str = str(command)
                 command_str = command_str.replace("\r\n", "<br>").replace("\n", "<br>")
-                self.add_html(report, 'Command:<br><br><div class="preformat">%s</div><br>' % command_str)
-                # temporary file to capture output error messages generated by Java
-                err_file_ref, err_file_path = _tempfile.mkstemp(suffix='.log')
-                err_file = os.fdopen(err_file_ref, "w")
+                with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'w') as f:
+                    f.write('Command:\n\n%s\n\nOutput:\n' % command_str)
                 try:
-                    output = _subprocess.check_output(command, stderr=err_file, cwd=self._path, shell=True)
-                    output_str = output.decode("utf-8", errors="replace").replace("\r\n", "<br>").replace("\n", "<br>")
-                    self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % output_str)
+                    with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'a') as f:
+                        _subprocess.run(command, stdout=f, stderr=f, cwd=self._path, shell=True, check=True)
                 except _subprocess.CalledProcessError as error:
-                    self.add_html(report, 'Output:<br><br><div class="preformat">%s</div>' % error.output.decode("utf-8", errors="replace"))
                     raise Exception("Error in %s, refer to process run report in logbook" % name)
                 finally:
-                    err_file.close()
-                    with open(err_file_path, 'r') as f:
-                        error_msg = f.read()
-                    os.remove(err_file_path)
-                    if error_msg:
-                        self.add_html(report, 'Error message(s):<br><br><div class="preformat">%s</div>' % error_msg)
+                    with open(_join(self._path, 'logFiles', '%s%s.log' % (name, name_suffix)), 'r') as f:
+                        self.add_html(report, '<div class="preformat">%s</div>' % f.read())
                     try:
                         # No raise on writing report error
                         # due to observed issue with runs generating reports which cause

--- a/src/main/resources/cvm.bat
+++ b/src/main/resources/cvm.bat
@@ -25,7 +25,7 @@ SET MODEL_DIR=%PROJECT_DRIVE%%PROJECT_DIRECTORY%
 :: run run_cvm.py
 ECHO Run CVM...
 CD /d %PROJECT_DRIVE%%PROJECT_DIRECTORY%\src\asim-cvm\
-python run_cvm.py %CVM_INPUT_DIR% %CVM_CONFIGS_DIR% %CVM_OUTPUT_DIR% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\logFiles\event-cvm.txt
+python run_cvm.py %CVM_INPUT_DIR% %CVM_CONFIGS_DIR% %CVM_OUTPUT_DIR% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\output\CVM\event-cvm.txt
 IF %ERRORLEVEL% NEQ 0 (GOTO :ERROR) else (GOTO :SUCCESS)
 
 :SUCCESS
@@ -36,9 +36,9 @@ IF %ERRORLEVEL% NEQ 0 (GOTO :ERROR) else (GOTO :SUCCESS)
 
     ::::::::::::::::::::::
     :: Post-process CVM outputs
-	python src/asim-cvm/scripts/generate_summary.py %MODEL_DIR% %CVM_OUTPUT_DIR% %SCENARIO_YEAR_WITH_SUFFIX%
+	python src/asim-cvm/scripts/generate_summary.py %MODEL_DIR% %CVM_OUTPUT_DIR% %SCENARIO_YEAR_WITH_SUFFIX% || GOTO :ERROR
     :: sort TAZ zone index in omx
-    python src/asim-cvm/scripts/set_zoneMapping.py cvm output
+    python src/asim-cvm/scripts/set_zoneMapping.py cvm output || GOTO :ERROR
 
     :: finish and exit batch file
     EXIT /B 0

--- a/src/main/resources/cvmEst.bat
+++ b/src/main/resources/cvmEst.bat
@@ -17,6 +17,11 @@ ECHO Create directory to store CVM Emp outputs...
 IF exist CVM ( echo CVM folder exists ) ELSE ( MD CVM && echo CVM folder created)
 CD ..
 
+CD Output
+ECHO Create directory to store CVM outputs...
+IF exist CVM ( echo CVM folder exists ) ELSE ( MD CVM && echo CVM folder created)
+CD ..
+
 SET MODEL_DIR=%PROJECT_DRIVE%%PROJECT_DIRECTORY%
 SET OUTPUT_DIR=%PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\CVM
 SET luz_data=%PROJECT_DRIVE%%PROJECT_DIRECTORY%\%luz_data_file%
@@ -24,23 +29,21 @@ SET luz_data=%PROJECT_DRIVE%%PROJECT_DIRECTORY%\%luz_data_file%
 :: Aggregate employment data to TAZ level
 ECHO Aggregate employment data to TAZ level
 CD /d %PROJECT_DRIVE%%PROJECT_DIRECTORY%\python\
-python aggregateEmpData.py %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use.csv %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use_taz.csv
+python aggregateEmpData.py %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use.csv %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use_taz.csv || GOTO :ERROR
 
 :: run MGRAEmpByEstSize2.py
 ECHO Run CVMEstablishmentSynthesis
-python MGRAEmpByEstSize2.py %MODEL_DIR% %OUTPUT_DIR% %luz_data% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\logFiles\event-cvmEmp.txt
+python MGRAEmpByEstSize2.py %MODEL_DIR% %OUTPUT_DIR% %luz_data% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\output\CVM\event-cvmEmp.txt || GOTO :ERROR
 
 :: Recode establishment zone IDs from TAZ to MGRA
 ECHO Recode establishment zone IDs from TAZ to MGRA
-python recodeSynthEstabToMGRA.py %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\CVM\SynthEstablishments.csv %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use.csv
-IF %ERRORLEVEL% NEQ 0 (GOTO :ERROR) else (GOTO :SUCCESS)
+python recodeSynthEstabToMGRA.py %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\CVM\SynthEstablishments.csv %PROJECT_DRIVE%%PROJECT_DIRECTORY%\input\land_use.csv || GOTO :ERROR
 
-:SUCCESS
-    ECHO CVM_Est complete!
-    ECHO %DATE% %TIME%
+ECHO CVM_Est complete!
+ECHO %DATE% %TIME%
 
-    :: finish and exit batch file
-    EXIT /B 0
+:: finish and exit batch file
+EXIT /B 0
 
 :ERROR
     CD /d %PROJECT_DRIVE%%PROJECT_DIRECTORY%

--- a/src/main/resources/htm.bat
+++ b/src/main/resources/htm.bat
@@ -28,7 +28,7 @@ SET OUTPUT_DIR=%PROJECT_DRIVE%%PROJECT_DIRECTORY%\output
 :: run run_htm.py
 ECHO Run HTM...
 CD /d %PROJECT_DRIVE%%PROJECT_DIRECTORY%\python\
-python run_htm.py %MODEL_DIR% %OUTPUT_DIR% %faf_file_name% %htm_input_file_name% %skim_period% %scenario_year% %scenario_year_with_suffix% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\logFiles\event-htm.txt
+python run_htm.py %MODEL_DIR% %OUTPUT_DIR% %faf_file_name% %htm_input_file_name% %skim_period% %scenario_year% %scenario_year_with_suffix% 2>>%PROJECT_DRIVE%%PROJECT_DIRECTORY%\output\HTM\event-htm.txt
 IF %ERRORLEVEL% NEQ 0 (GOTO :ERROR) else (GOTO :SUCCESS)
 
 :SUCCESS


### PR DESCRIPTION
## Proposed changes

Write process run report logs to logFiles directory then read into Emme logbook, instead of writing directly to Emme logbook. Log file names are structured as script_file_name.cmd_iter1.log.
Also changes location of CVM and HTM logs from logFiles directory to their respective output directories
[AB#2686](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/2686) [AB#2687](https://dev.azure.com/SANDAG-ADS/3af839ac-e181-4605-b11c-60f38a706246/_workitems/edit/2687)

## Impact

Process run reports will be viewable from the new log files without having to open Emme, making it easier to check errors and output

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Tested a full model run with the changes to the main process run function
- [x] Tested re-run of iteration 3 transit assignment with same changes made to transit assignment function

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
