### PR TITLE
Database copy error crash

### DIFF
--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -318,7 +318,7 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
             self._report.append("End: %s" % _time.strftime("%c"))
         return emmebank_paths
 
-    def _copy_dir(self, src, dst, file_masks, dir_masks=None,check_metadata=False):
+    def _copy_dir(self, src, dst, file_masks, check_metadata=False):
         
         # windows xcopy is much faster than shutil
         # upgrading xcopy to a faster robocopy
@@ -329,8 +329,7 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
             flags = ['/E', '/Z', '/MT:8']
         try:
             exclude_file_list = file_masks
-            exclude_dir_list = dir_masks
-            output = _subprocess.check_output(['robocopy', src, dst] + flags + ["/XF"] + exclude_file_list + ["/XD"] + exclude_dir_list)
+            output = _subprocess.check_output(['robocopy', src, dst] + flags + ["/XF"] + exclude_file_list + ["/XD"] + exclude_file_list)
             self._report.append(output)
             self._report.append(_time.strftime("%c"))
         except _subprocess.CalledProcessError as error:

--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -198,8 +198,11 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
         title_fcn = lambda t: t[8:] if t.startswith("(local)") else t
         # copy all files (except Emme project, and other file_masks)
         self._copy_dir(src=local_dir, dst=remote_dir, file_masks=file_masks)
-        emmebank_paths = self._copy_emme_data(
+        
+        try:emmebank_paths = self._copy_emme_data(
             src=local_dir, dst=remote_dir, title_fcn=title_fcn, scenario_id=scenario_id)
+        except:
+            self._copy_dir(src=_join(local_dir, "emme_project"), dst=_join(remote_dir, "emme_project"), file_masks=['*locki*'])
         
         
         self.log_report()

--- a/src/main/emme/toolbox/utilities/file_manager.py
+++ b/src/main/emme/toolbox/utilities/file_manager.py
@@ -318,7 +318,7 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
             self._report.append("End: %s" % _time.strftime("%c"))
         return emmebank_paths
 
-    def _copy_dir(self, src, dst, file_masks, check_metadata=False):
+    def _copy_dir(self, src, dst, file_masks, dir_masks=None,check_metadata=False):
         
         # windows xcopy is much faster than shutil
         # upgrading xcopy to a faster robocopy
@@ -329,7 +329,8 @@ class FileManagerTool(_m.Tool(), gen_utils.Snapshot):
             flags = ['/E', '/Z', '/MT:8']
         try:
             exclude_file_list = file_masks
-            output = _subprocess.check_output(['robocopy', src, dst] + flags + ["/XF"] + exclude_file_list + ["/XD"] + exclude_file_list)
+            exclude_dir_list = dir_masks
+            output = _subprocess.check_output(['robocopy', src, dst] + flags + ["/XF"] + exclude_file_list + ["/XD"] + exclude_dir_list)
             self._report.append(output)
             self._report.append(_time.strftime("%c"))
         except _subprocess.CalledProcessError as error:


### PR DESCRIPTION
## Proposed changes

Edits the copy tool such that the script uses a Windows robocopy in the event that the EMME database cannot be read by the EMME script.

## Impact

Recent runs of ABM have all resulted in an error in which the EMME databases could not be read by the EMME script on the remote drive. Thus, the databases could not be copied over from the local drive to the remote drive, forcing users to manually go into the system and close the programs before copying over the rest of the EMME databases. This caused downtime in metrics that required these databases to be within the remote drive. This update will instead initiate a Windows robocopy in the event that the EMME script fails to copy over all the databases to the remove drive.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

- [x] Full 2022 scenario run
- [ ] Checks for byte size between both remote and local drive
  - This check has not been checked within a scenario run and has only been checked by manual copy locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Further comments
Although not the explicit usage of the following method, the `_copy_dir` method is a good general copy method for instances where other copying methods fail or run into errors. In the future, an additional update to separate the file masks into `file_masks` and `dir_masks` could be beneficial in case any specific directories and files would want to be excluded in a single step. However, this update is not within the scope of this PR and would require further testing.

