### PR TITLE
Remove bike reclassification

### DIFF
--- a/src/asim/scripts/bike_route_choice/bike_edge_utils.csv
+++ b/src/asim/scripts/bike_route_choice/bike_edge_utils.csv
@@ -5,23 +5,23 @@ util_distance_general,Edge length (distance) in miles,distance,-10.93
 util_medium_upslope,Edge slope in range [1%-3.5%],"@df.distance * ((df.gain / (df.distance * 5280) >= 0.01) & (df.gain / (df.distance * 5280) <= 0.035)).astype(int)",-9.012
 util_high_upslope,Edge slope > 3.5%,"@df.distance * (df.gain / (df.distance * 5280) > 0.035).astype(int)",-18.19
 # per class penalties - large roadways,,,
-util_lg_protected,Large roadway w/ protected lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & df.cycleTrack ).astype(int)",0.1748
-util_lg_painted,Large roadway w/ painted lanes & no protected lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & (~df.cycleTrack) & (df.bikeClass == 2) ).astype(int)",-3.158
-util_lg_nofacils,Large roadway w/o bike lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & (~df.cycleTrack) & ~(df.bikeClass == 2) ).astype(int)",-2.513
+util_lg_protected,Large roadway w/ protected lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & (df.bikeClass == 4) ).astype(int)",0.1748
+util_lg_painted,Large roadway w/ painted lanes & no protected lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & (df.bikeClass == 2) ).astype(int)",-3.158
+util_lg_nofacils,Large roadway w/o bike lanes,"@df.distance * ( df.functionalClass.isin([3,4]) & (~(df.bikeClass == 4)) & ~(df.bikeClass == 2) ).astype(int)",-2.513
 # per-class penalties - medium roadways,,,
-# util_med_protected,Medium roadway w/ protected lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & df.cycleTrack ).astype(int)",0.000
-util_med_painted,Medium roadway w/ painted lanes & no protected lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & (~df.cycleTrack) & (df.bikeClass == 2) ).astype(int)",-0.5464
-util_med_nofacils,Medium roadway w/o bike lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & (~df.cycleTrack) & ~(df.bikeClass == 2) ).astype(int)",-1.235
+# util_med_protected,Medium roadway w/ protected lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & (df.bikeClass == 4) ).astype(int)",0.000
+util_med_painted,Medium roadway w/ painted lanes & no protected lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & (df.bikeClass == 2) ).astype(int)",-0.5464
+util_med_nofacils,Medium roadway w/o bike lanes,"@df.distance * ( df.functionalClass.isin([5,6]) & (~(df.bikeClass == 4)) & ~(df.bikeClass == 2) ).astype(int)",-1.235
 # per class penalties - residential roadways,,,
-util_res_protected,Residential roadway w/ protected lanes,"@df.distance * ( (df.functionalClass == 7) & df.cycleTrack ).astype(int)",-0.9835
-util_res_painted,Residential roadway w/ painted lanes & no protected lanes,"@df.distance * ( (df.functionalClass == 7) & (~df.cycleTrack) & (df.bikeClass == 2) ).astype(int)",0.9288
-util_res_nofacils,Residential roadway w/o bike lanes,"@df.distance * ( (df.functionalClass == 7) & (~df.cycleTrack) & ~(df.bikeClass == 2) ).astype(int)",-1.901
+util_res_protected,Residential roadway w/ protected lanes,"@df.distance * ( (df.functionalClass == 7) & (df.bikeClass == 4) ).astype(int)",-0.9835
+util_res_painted,Residential roadway w/ painted lanes & no protected lanes,"@df.distance * ( (df.functionalClass == 7) & (df.bikeClass == 2) ).astype(int)",0.9288
+util_res_nofacils,Residential roadway w/o bike lanes,"@df.distance * ( (df.functionalClass == 7) & (~(df.bikeClass == 4)) & ~(df.bikeClass == 2) ).astype(int)",-1.901
 # per class penalties - non-vehicle routes,,,
-util_cycleway,Cycleway,"@df.distance * ( (~df.functionalClass.isin([3,4,5,6,7,10])) & (df.bikeClass == 2) ).astype(int)",0.4152
+util_cycleway,Cycleway,"@df.distance * ( (~df.functionalClass.isin([3,4,5,6,7,10])) & ((df.bikeClass == 2) | (df.bikeClass == 4)) ).astype(int)",0.4152
 util_sup,Shared-Use Path,"@df.distance * ( (~df.functionalClass.isin([3,4,5,6,7,10])) & (df.bikeClass == 1) ).astype(int)",-1.705
 util_pedzone,Pedestrian Zone,"@df.distance * ( (~df.functionalClass.isin([3,4,5,6,7,10])) & (~df.bikeClass.isin([1,2])) ).astype(int)",-4.021
 # FIXME better way to check wrong way?,,,
-util_wrong_way,Wrong Way - no lanes in direction of travel and no bike lane,"@df.distance * ( (~df.cycleTrack) & (~(df.bikeClass == 2)) & (df.lanes == 0) ).astype(int)",-3.202
+util_wrong_way,Wrong Way - no lanes in direction of travel and no bike lane,"@df.distance * ( (~(df.bikeClass == 4)) & (~(df.bikeClass == 2)) & (df.lanes == 0) ).astype(int)",-3.202
 # The above coefficients are adapted from Lukawska et al. (2023),,,
 
 

--- a/src/asim/scripts/bike_route_choice/bike_net_reader.py
+++ b/src/asim/scripts/bike_route_choice/bike_net_reader.py
@@ -54,8 +54,6 @@ def create_and_attribute_edges(
                 "ABBikeClas": "bikeClass",
                 "AB_Lanes": "lanes",
                 "Func_Class": "functionalClass",
-                "Bike2Sep": "cycleTrack",
-                "Bike3Blvd": "bikeBlvd",
                 "SPEED": "speedLimit",
             }
         )
@@ -73,8 +71,6 @@ def create_and_attribute_edges(
                 "functionalClass",
                 "centroidConnector",
                 "autosPermitted",
-                "cycleTrack",
-                "bikeBlvd",
                 "distance",
                 "gain",
                 "speedLimit",
@@ -93,8 +89,6 @@ def create_and_attribute_edges(
                 "BABikeClas": "bikeClass",
                 "BA_Lanes": "lanes",
                 "Func_Class": "functionalClass",
-                "Bike2Sep": "cycleTrack",
-                "Bike3Blvd": "bikeBlvd",
                 "SPEED": "speedLimit",
             }
         )
@@ -113,8 +107,6 @@ def create_and_attribute_edges(
                 "functionalClass",
                 "centroidConnector",
                 "autosPermitted",
-                "cycleTrack",
-                "bikeBlvd",
                 "distance",
                 "gain",
                 "speedLimit",


### PR DESCRIPTION
## Proposed changes

Previously, protected bike lanes (Class IV) and bike boulevards (Class V) were coded in the bike network with ABBikeClas/BABikeClas values 2 and 3 respectively, with additional attributes Bike2Sep and Bike3Blvd to differentiate them from painted bike lanes (Class II) and sharrows (Class III). When the network was updated to instead code these with ABBikeClas/BABikeClas values 4 and 5, a reclassification process was added to the TNED ETL to maintain compatibility with the Java-based bike logsum process. This reclassification process recoded bike class 4 to bike class 2 with Bike2Sep, and bike class 5 to bike class 3 with Bike3Blvd.

The development of the new Python-based bike logsum process made updating the config files to support bike class 4 and 5 easier, but this change was not made during the development of this process so that the existing post-reclassification networks could be used. This PR adds those config changes so that the reclassification process can be removed from the TNED ETL, removing the Bike2Sep and Bike3Blvd attributes.

Upon including this PR in a release, all networks will need to be updated to remove reclassification and re-run bike logsums.

## Impact

Minimal to no impact on bike logsum output, comparing network with reclassification without this PR to network without reclassification with this PR. All bike networks will need to be updated.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran bike model with changes on 2025RP 2022 bike network without reclassification, comparing output to existing 2025RP 2022 bike logsum output. Minimal difference in logsum output was found, assumed to be due to randomization.
<img width="1387" height="1000" alt="image" src="https://github.com/user-attachments/assets/24d0b7b8-75cb-4c39-b0a2-c2da85de4636" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
