### PR TITLE
bug fix on the shadow price utility adjustments to preschool trips

### DIFF
--- a/src/asim/configs/resident/school_location.csv
+++ b/src/asim/configs/resident/school_location.csv
@@ -20,7 +20,7 @@ util_ABM2calibration_1-2miles,ABM2 calibration_1-2miles,@(_DIST<2) * (_DIST>=1),
 util_ABM2calibration_2-3miles,ABM2 calibration_2-3miles,@(_DIST<3) * (_DIST>=2),coef_zero,coef_abmcalib_23miles,coef_abmcalib_23miles,coef_abmcalib_23miles
 util_ABM2calibration_0-20miles,ABM2 calibration_0-20miles,@(_DIST<20) * (_DIST),coef_zero,coef_abmcalib_20miles,coef_abmcalib_20miles,coef_abmcalib_20miles
 #,,,,,,
-#calibration constants,,,
+#calibration constants,,,,,,
 util_Calibration 0-2 - miles,Calibration 0-2 - miles,@_DIST<=2,,coef_distance_0_2miles,coef_distance_2_5miles,coef_distance_5_10miles
 util_Calibration 2-5 - miles,Calibration 2-5 - miles,@(_DIST>2) * (_DIST<=5),,coef_distance_0_2miles,coef_distance_2_5miles,coef_distance_5_10miles
 util_Calibration 5-10 - miles,Calibration 5-10 - miles,@(_DIST>5) * (_DIST<=10),,coef_distance_0_2miles,coef_distance_2_5miles,coef_distance_5_10miles

--- a/src/asim/configs/resident/school_location.csv
+++ b/src/asim/configs/resident/school_location.csv
@@ -13,7 +13,7 @@ util_Distance - age03_prek,Distance - age 0 to 3,"@np.where(df.age<3,_DIST.clip(
 util_LoggedSize,Logged Size variable - University specific,@df['size_term'].apply(np.log1p),coef_lnSize,coef_lnSize,coef_lnSize,coef_lnSize
 util_no_attractions,no attractions if logged university size is zero,@df['size_term']==0,-999,-999,-999,-999
 util_sample_of_corrections_factor,Sample of alternatives correction factor,"@np.minimum(np.log(df.pick_count/df.prob), 60)",1,1,1,1
-util_sp_utility_adjustment,shadow price utility adjustment,@df['shadow_price_utility_adjustment'],1,1,1
+util_sp_utility_adjustment,shadow price utility adjustment,@df['shadow_price_utility_adjustment'],1,1,1,1
 #,,,,,,
 util_ABM2calibration_0-1miles,ABM2 calibration_0-1miles,@(_DIST<1),coef_zero,coef_abmcalib_01miles,coef_abmcalib_01miles,coef_abmcalib_01miles
 util_ABM2calibration_1-2miles,ABM2 calibration_1-2miles,@(_DIST<2) * (_DIST>=1),coef_zero,coef_abmcalib_12miles,coef_abmcalib_12miles,coef_abmcalib_12miles


### PR DESCRIPTION
## Proposed changes

There is an error in the [school location](https://github.com/SANDAG/ABM/blob/main/src/asim/configs/resident/school_location.csv#L16) config file, which caused that the shadow pricing price utility adjustment was not being applied to preschool trips.

## Impact

will add the model outputs comparison summary later

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] A full model run with this bug fix was done
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

