### PR TITLE
Update path for manifest queueing system

### DIFF
--- a/src/main/python/datalake_exporter.py
+++ b/src/main/python/datalake_exporter.py
@@ -222,7 +222,10 @@ def write_manifest(
     root_directory = check_root(container)
 
     lake_file_name = build_blob_path(
-        root_directory, "_manifest", release_version, f"upload_{parent_dir_name}.json"
+        root_directory,
+        "_manifest/pending",
+        release_version,
+        f"upload_{parent_dir_name}.json",
     )
     manifest["timing"]["manifest_uploaded_at"] = datetime.datetime.now(
         datetime.timezone(datetime.timedelta(hours=-8))
@@ -264,9 +267,7 @@ def write_to_datalake(output_path, models, exclude, env):
         if is_asim:
             model_metadata = get_model_metadata(model, output_path)
             prefix = model_metadata["prefix"]
-        elif model == "CVM":
-            prefix = "final_"
-        elif model == "HTM":
+        elif model == "CVM" or model == "HTM":
             prefix = "final_"
         else:
             prefix = ""
@@ -322,9 +323,7 @@ def write_to_datalake(output_path, models, exclude, env):
                 parent_dir_name,
                 container,
             )
-        elif model == "CVM":
-            prefix = "final_"
-        elif model == "HTM":
+        elif model == "CVM" or model == "HTM":
             prefix = "final_"
         else:
             prefix = ""
@@ -391,7 +390,6 @@ def write_to_datalake(output_path, models, exclude, env):
                 container.upload_blob(name=lake_file_name, data=data)
         except (FileNotFoundError, KeyError):
             print(("%s not found" % file), file=sys.stderr)
-            pass
     # upload validation files to datalake validation folder
     validation_files = [
         os.path.join(
@@ -444,7 +442,6 @@ def write_to_datalake(output_path, models, exclude, env):
                 container.upload_blob(name=lake_file_name, data=data)
         except (FileNotFoundError, KeyError):
             print(("%s not found" % file), file=sys.stderr)
-            pass
 
     # Update manifest timestamp for completion of upload process
     manifest["timing"]["load_end_at"] = datetime.datetime.now(


### PR DESCRIPTION
## Proposed changes

This fix adds a pending subdirectory to the existing manifest writing location. This is needed as in the off chance/edge case of two scenarios finishing and writing a manifest at the same time, only the later one will be read. 

## Impact

This will make it easier for the ingestion script to identify which manifests have been loaded and which are still pending, depending on which folder the manifest is in.

## Types of changes

What types of changes does your code introduce to ABM?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## How has this been tested?

Current existing script works, just updating the path so nothing should break.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
